### PR TITLE
keyswitch unit test function

### DIFF
--- a/src/include/lwekeyswitch.h
+++ b/src/include/lwekeyswitch.h
@@ -9,12 +9,10 @@
 #include "lwesamples.h"
 
 struct LweKeySwitchKey {
+    int n; ///< length of the input key: s'
+    int t; ///< decomposition length
     int basebit; ///< log_2(base)
     int base; ///< decomposition base: a power of 2 
-    int n; ///< length of the input key: s'
-    int l; ///< decomposition length
-    uint32_t mask; ///< mask=base-1, used for mod base ops
-    const LweParams* in_params; ///< params of the input key s'
     const LweParams* out_params; ///< params of the output key s 
     LweSample* ks0_raw; //tableau qui contient tout les Lwe samples de taille nlbase
     LweSample** ks1_raw;// de taille nl  pointe vers un tableau ks0_raw dont les cases sont espaceés de base positions
@@ -22,7 +20,7 @@ struct LweKeySwitchKey {
     // de taille n pointe vers ks1 un tableau dont les cases sont espaceés de ell positions
 
 #ifdef __cplusplus
-    LweKeySwitchKey(int basebit, int kslength, const LweParams* in_params, const LweParams* out_params);
+    LweKeySwitchKey(int n, int t, int basebit, const LweParams* out_params);
     ~LweKeySwitchKey();
     LweKeySwitchKey(const LweKeySwitchKey&) = delete;
     void operator=(const LweKeySwitchKey&) = delete;
@@ -39,8 +37,8 @@ EXPORT void free_LweKeySwitchKey_array(int nbelts, LweKeySwitchKey* ptr);
 
 //initialize the LweKeySwitchKey structure
 //(equivalent of the C++ constructor)
-EXPORT void init_LweKeySwitchKey(LweKeySwitchKey* obj, int basebit, int kslength, const LweParams* in_params, const LweParams* out_params);
-EXPORT void init_LweKeySwitchKey_array(int nbelts, LweKeySwitchKey* obj, int basebit, int kslength, const LweParams* in_params, const LweParams* out_params);
+EXPORT void init_LweKeySwitchKey(LweKeySwitchKey* obj, int n, int t, int basebit, const LweParams* out_params);
+EXPORT void init_LweKeySwitchKey_array(int nbelts, LweKeySwitchKey* obj, int n, int t, int basebit, const LweParams* out_params);
 
 //destroys the LweKeySwitchKey structure
 //(equivalent of the C++ destructor)
@@ -49,8 +47,8 @@ EXPORT void destroy_LweKeySwitchKey_array(int nbelts, LweKeySwitchKey* obj);
  
 //allocates and initialize the LweKeySwitchKey structure
 //(equivalent of the C++ new)
-EXPORT LweKeySwitchKey* new_LweKeySwitchKey(int basebit, int kslength, const LweParams* in_params, const LweParams* out_params);
-EXPORT LweKeySwitchKey* new_LweKeySwitchKey_array(int nbelts, int basebit, int kslength, const LweParams* in_params, const LweParams* out_params);
+EXPORT LweKeySwitchKey* new_LweKeySwitchKey(int n, int t, int basebit, const LweParams* out_params);
+EXPORT LweKeySwitchKey* new_LweKeySwitchKey_array(int nbelts, int n, int t, int basebit, const LweParams* out_params);
 
 //destroys and frees the LweKeySwitchKey structure
 //(equivalent of the C++ delete)

--- a/src/libtfhe/CMakeLists.txt
+++ b/src/libtfhe/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SRCS
     tlwefftoperations.cpp
     toruspolynomial-functions.cpp
     boot-gates.cpp
+    lwe-keyswitch-functions.cpp
     )
 
 

--- a/src/libtfhe/autogenerated.cpp
+++ b/src/libtfhe/autogenerated.cpp
@@ -264,12 +264,12 @@ EXPORT void free_LweKeySwitchKey_array(int nbelts, LweKeySwitchKey* ptr) {
 
 //initialize the key structure
 //(equivalent of the C++ constructor)
-EXPORT void init_LweKeySwitchKey(LweKeySwitchKey* obj, int basebit, int kslength, const LweParams* in_params, const LweParams* out_params) {
-    new(obj) LweKeySwitchKey(basebit,kslength,in_params,out_params);
+EXPORT void init_LweKeySwitchKey(LweKeySwitchKey* obj, int n, int t, int basebit, const LweParams* out_params) {
+    new(obj) LweKeySwitchKey(n,t,basebit,out_params);
 }
-EXPORT void init_LweKeySwitchKey_array(int nbelts, LweKeySwitchKey* obj, int basebit, int kslength, const LweParams* in_params, const LweParams* out_params) {
+EXPORT void init_LweKeySwitchKey_array(int nbelts, LweKeySwitchKey* obj, int n, int t, int basebit, const LweParams* out_params) {
     for (int i=0; i<nbelts; i++) {
-	new(obj+i) LweKeySwitchKey(basebit,kslength,in_params,out_params);
+	new(obj+i) LweKeySwitchKey(n,t,basebit,out_params);
     }
 }
 
@@ -286,12 +286,12 @@ EXPORT void destroy_LweKeySwitchKey_array(int nbelts, LweKeySwitchKey* obj) {
  
 //allocates and initialize the LweKeySwitchKey structure
 //(equivalent of the C++ new)
-EXPORT LweKeySwitchKey* new_LweKeySwitchKey(int basebit, int kslength, const LweParams* in_params, const LweParams* out_params) {
-    return new LweKeySwitchKey(basebit,kslength,in_params,out_params);
+EXPORT LweKeySwitchKey* new_LweKeySwitchKey(int n, int t, int basebit, const LweParams* out_params) {
+    return new LweKeySwitchKey(n,t,basebit,out_params);
 }
-EXPORT LweKeySwitchKey* new_LweKeySwitchKey_array(int nbelts, int basebit, int kslength, const LweParams* in_params, const LweParams* out_params) {
+EXPORT LweKeySwitchKey* new_LweKeySwitchKey_array(int nbelts, int n, int t, int basebit, const LweParams* out_params) {
     LweKeySwitchKey* obj = alloc_LweKeySwitchKey_array(nbelts);
-    init_LweKeySwitchKey_array(nbelts,obj,basebit,kslength,in_params,out_params);
+    init_LweKeySwitchKey_array(nbelts, obj, n,t,basebit,out_params);
     return obj;
 }
 

--- a/src/libtfhe/lwe-keyswitch-functions.cpp
+++ b/src/libtfhe/lwe-keyswitch-functions.cpp
@@ -1,0 +1,96 @@
+#ifndef TFHE_TEST_ENVIRONMENT
+#include <iostream>
+#include "lwe-functions.h"
+#include "lwekeyswitch.h"
+
+using namespace std;
+#else
+#undef EXPORT
+#define EXPORT
+#endif
+
+/**
+ * fills the KeySwitching key array
+ * @param result The (n x t x base) array of samples. 
+ *        result[i][j][k] encodes k.s[i]/base^(j+1)
+ * @param out_key The LWE key to encode all the output samples 
+ * @param out_alpha The standard deviation of all output samples
+ * @param in_key The (binary) input key
+ * @param n The size of the input key
+ * @param t The precision of the keyswitch (technically, 1/2.base^t)
+ * @param basebit Log_2 of base
+ */
+void lweCreateKeySwitchKey_fromArray(LweSample*** result, 
+	const LweKey* out_key, const double out_alpha, 
+	const int* in_key, const int n, const int t, const int basebit){
+    const int base=1<<basebit;       // base=2 in [CGGI16]
+
+    for(int i=0;i<n;i++) {
+    	for(int j=0;j<t;j++){
+    	    for(int k=0;k<base;k++){
+		Torus32 x=(in_key[i]*k)*(1<<(32-(j+1)*basebit));
+		lweSymEncrypt(&result[i][j][k],x,out_alpha,out_key);
+		//printf("i,j,k,ki,x,phase=%d,%d,%d,%d,%d,%d\n",i,j,k,in_key->key[i],x,lwePhase(&result->ks[i][j][k],out_key));
+    	    }
+    	}
+    }
+}
+
+
+/**
+ * translates the message of the result sample by -sum(a[i].s[i]) where s is the secret
+ * embedded in ks.
+ * @param result the LWE sample to translate by -sum(ai.si). 
+ * @param ks The (n x t x base) key switching key 
+ *        ks[i][j][k] encodes k.s[i]/base^(j+1)
+ * @param params The common LWE parameters of ks and result
+ * @param ai The input torus array
+ * @param n The size of the input key
+ * @param t The precision of the keyswitch (technically, 1/2.base^t)
+ * @param basebit Log_2 of base
+ */
+void lweKeySwitchTranslate_fromArray(LweSample* result, 
+	const LweSample*** ks, const LweParams* params, 
+	const Torus32* ai, 
+	const int n, const int t, const int basebit){
+    const int base=1<<basebit;       // base=2 in [CGGI16]
+    const int32_t prec_offset=1<<(32-(1+basebit*t)); //precision
+    const int mask=base-1;
+
+    for (int i=0;i<n;i++){
+	const uint32_t aibar=ai[i]+prec_offset;
+	for (int j=0;j<t;j++){
+	    const uint32_t aij=(aibar>>(32-(j+1)*basebit)) & mask;
+	    lweSubTo(result,&ks[i][j][aij],params);
+	}
+    }
+}
+
+
+
+EXPORT void lweCreateKeySwitchKey(LweKeySwitchKey* result, const LweKey* in_key, const LweKey* out_key){
+    const int n=result->n;
+    const int basebit=result->basebit;
+    const int t=result->t;
+
+    //TODO check the parameters
+
+
+    lweCreateKeySwitchKey_fromArray(result->ks,
+	    out_key, out_key->params->alpha_min,
+	    in_key->key, n, t, basebit);
+}
+
+//sample=(a',b')
+EXPORT void lweKeySwitch(LweSample* result, const LweKeySwitchKey* ks, const LweSample* sample){
+    const LweParams* params=ks->out_params;
+    const int n=ks->n;
+    const int basebit=ks->basebit;
+    const int t=ks->t;
+
+    lweNoiselessTrivial(result,sample->b,params);
+    lweKeySwitchTranslate_fromArray(result,
+	    (const LweSample***) ks->ks, params,
+	    sample->a, n, t, basebit);
+}
+

--- a/src/libtfhe/lwebootstrappingkey.cpp
+++ b/src/libtfhe/lwebootstrappingkey.cpp
@@ -5,8 +5,8 @@
 #include "lwekeyswitch.h"
 #include "tgsw.h"
 
-const int basebit = 2;
-const int kslength = 32/basebit;
+const int basebit = 1;
+const int kslength = 15;
 
 using namespace std;
 
@@ -16,9 +16,10 @@ LweBootstrappingKey::LweBootstrappingKey(const LweParams* in_out_params, const T
     this->accum_params= bk_params->tlwe_params;
     this->extract_params=&accum_params->extracted_lweparams;
     const int n = in_out_params->n;
+    const int N = extract_params->n;
 
     this->bk=new_TGswSample_array(n,this->bk_params);
-    this->ks=new_LweKeySwitchKey(basebit, kslength, extract_params, in_out_params);
+    this->ks=new_LweKeySwitchKey(N, kslength, basebit, in_out_params);
 }
 
 LweBootstrappingKey::~LweBootstrappingKey() {
@@ -34,9 +35,10 @@ LweBootstrappingKeyFFT::LweBootstrappingKeyFFT(const LweParams* in_out_params, c
     this->accum_params= bk_params->tlwe_params;
     this->extract_params=&accum_params->extracted_lweparams;
     const int n = in_out_params->n;
+    const int N = extract_params->n;
 
     this->bk=new_TGswSampleFFT_array(n,this->bk_params);
-    this->ks=new_LweKeySwitchKey(basebit, kslength, extract_params, in_out_params);
+    this->ks=new_LweKeySwitchKey(N, kslength, basebit, in_out_params);
 }
 
 LweBootstrappingKeyFFT::~LweBootstrappingKeyFFT() {

--- a/src/libtfhe/lwekeyswitch.cpp
+++ b/src/libtfhe/lwekeyswitch.cpp
@@ -1,27 +1,25 @@
 #include "lwekeyswitch.h"
 
 
-LweKeySwitchKey::LweKeySwitchKey(int basebit, int kslength, const LweParams* in_params, const LweParams* out_params){
+LweKeySwitchKey::LweKeySwitchKey(int n, int t, int basebit, const LweParams* out_params){
     this->basebit=basebit;
-    this->base=1<<basebit;   
-    this->in_params=in_params; 
     this->out_params=out_params; 
-    this->mask= base-1;
-    this->n=in_params->n;
-    this->l=kslength;
-    ks0_raw = new_LweSample_array(n*l*base,out_params);
-    ks1_raw = new LweSample*[n*l];
+    this->n=n;
+    this->t=t;
+    this->base=1<<basebit;
+    ks0_raw = new_LweSample_array(n*t*base,out_params);
+    ks1_raw = new LweSample*[n*t];
     ks = new LweSample**[n];
 
    
-    for (int p = 0; p < n*l; ++p)
+    for (int p = 0; p < n*t; ++p)
 	    ks1_raw[p] = ks0_raw + base*p;
 	for (int p = 0; p < n; ++p)
-	    ks[p] = ks1_raw + l*p;
+	    ks[p] = ks1_raw + t*p;
 }
 
 LweKeySwitchKey::~LweKeySwitchKey() {
-	delete_LweSample_array(in_params->n*l*base,ks0_raw);
+	delete_LweSample_array(n*t*base,ks0_raw);
     delete[] ks1_raw;
     delete[] ks;
 }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(GOOGLETEST_SOURCES
     arithmetic_test.cpp
     lwe_test.cpp
     polynomial_test.cpp
+    lwekeyswitch_test.cpp
     )
 
 foreach (FFT_PROCESSOR IN LISTS FFT_PROCESSORS) 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -35,7 +35,7 @@ add_executable(test-lwe-${FFT_PROCESSOR} test-lwe.cpp ${TFHE_HEADERS})
 add_executable(test-multiplication-${FFT_PROCESSOR} test-multiplication.cpp ${TFHE_HEADERS})
 add_executable(test-tlwe-${FFT_PROCESSOR} test-tlwe.cpp ${TFHE_HEADERS})
 
-target_link_libraries(unittests-${FFT_PROCESSOR} ${RUNTIME_LIBS} ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(unittests-${FFT_PROCESSOR} ${RUNTIME_LIBS} ${GTEST_BOTH_LIBRARIES} -lgmock -lpthread)
 target_link_libraries(test-bootstrapping-${FFT_PROCESSOR} ${RUNTIME_LIBS})
 target_link_libraries(test-bootstrapping-fft2-${FFT_PROCESSOR} ${RUNTIME_LIBS})
 target_link_libraries(test-deb-boot-${FFT_PROCESSOR} ${RUNTIME_LIBS})

--- a/src/test/lwekeyswitch_test.cpp
+++ b/src/test/lwekeyswitch_test.cpp
@@ -1,0 +1,148 @@
+#include <gtest/gtest.h>
+#include "lwe-functions.h"
+#include "lwekeyswitch.h"
+#include "numeric_functions.h"
+using namespace std;
+
+namespace {
+    class LweKeySwitchTest: public ::testing::Test {
+	protected:
+	    virtual void SetUp() {
+		params500_0 = new_LweParams(500,0.,1.);
+		params250_0 = new_LweParams(500,0.,1.);
+		params500_1em5 = new_LweParams(500,1e-5,1.);
+		key250 = new_LweKey(params250_0);
+		key500 = new_LweKey(params500_0);
+	    }
+	    virtual void TearDown() {
+		delete_LweParams(params250_0);
+		delete_LweParams(params500_0);
+		delete_LweParams(params500_1em5);
+		delete_LweKey(key250);
+		delete_LweKey(key500);
+	    }
+
+	public:
+	    LweParams* params250_0;
+	    LweParams* params500_0;
+	    LweParams* params500_1em5;
+	    LweKey* key250;
+	    LweKey* key500;
+
+	    //mock lwe encryption
+	    void lweSymEncrypt(LweSample* result,const Torus32 message,const double alpha, const LweKey* key) {
+		lweNoiselessTrivial(result, message, key->params);
+		result->current_variance = alpha*alpha;
+	    }
+
+#define TFHE_TEST_ENVIRONMENT 1
+#include "../libtfhe/lwe-keyswitch-functions.cpp"
+    };
+
+    /**
+     * fills the KeySwitching key array
+     * @param result The (n x t x base) array of samples. 
+     *        result[i][j][k] encodes k.s[i]/base^(j+1)
+     * @param out_key The LWE key to encode all the output samples 
+     * @param out_alpha The standard deviation of all output samples
+     * @param in_key The (binary) input key
+     * @param n The size of the input key
+     * @param t The precision of the keyswitch (technically, 1/2.base^t)
+     * @param basebit Log_2 of base
+     */
+    //void lweCreateKeySwitchKey_fromArray(LweSample*** result, 
+    TEST_F(LweKeySwitchTest, lweCreateKeySwitchKey_fromArray) {
+	LweKeySwitchKey* test = new_LweKeySwitchKey(300,14,2,params500_1em5);
+	//int n = test->out_params->n;
+	double alpha = 1e-5;
+	int N = test->n;
+	int t = test->t;
+	int basebit = test->basebit;
+	int base = test->base;
+	int* in_key = new int[N];
+	for (int i=0; i<N; i++) in_key[i]=(uniformTorus32_distrib(generator)%2==0?1:0);
+	lweCreateKeySwitchKey_fromArray(test->ks,key500,alpha,in_key,N,t,basebit);
+	for (int i=0; i<N; i++) {
+	    for (int j=0; j<t; j++) {
+		for (int k=0; k<base; k++) {
+		    LweSample* ks_ijk = &test->ks[i][j][k];
+		    ASSERT_EQ(alpha*alpha,ks_ijk->current_variance);
+		    ASSERT_EQ(k*in_key[i]*1<<(32-(j+1)*basebit),ks_ijk->b);
+		}
+	    }
+	}
+	delete[] in_key;
+	delete_LweKeySwitchKey(test);
+    }
+
+    /**
+     * translates the message of the result sample by -sum(a[i].s[i]) where s is the secret
+     * embedded in ks.
+     * @param result the LWE sample to translate by -sum(ai.si). 
+     * @param ks The (n x t x base) key switching key 
+     *        ks[i][j][k] encodes k.s[i]/base^(j+1)
+     * @param params The common LWE parameters of ks and result
+     * @param ai The input torus array
+     * @param n The size of the input key
+     * @param t The precision of the keyswitch (technically, 1/2.base^t)
+     * @param basebit Log_2 of base
+     */
+    //void lweKeySwitchTranslate_fromArray(LweSample* result, 
+    //	    const LweSample*** ks, const LweParams* params, 
+    //	    const Torus32* ai, 
+    //	    const int n, const int t, const int basebit)
+    TEST_F(LweKeySwitchTest, lweKeySwitchTranslate_fromArray) {
+	LweKeySwitchKey* test = new_LweKeySwitchKey(300,14,2,params500_1em5);
+	//int n = test->out_params->n;
+	double alpha = 1e-5;
+	int N = test->n;
+	int t = test->t;
+	int basebit = test->basebit;
+	int base = test->base;
+	const int32_t prec_offset=1<<(32-(1+basebit*t)); //precision
+	const uint32_t prec_mask=-(1<<(32-(basebit*t))); //precision
+	//printf("prec_offset: %08x\n",prec_offset);
+	//printf("prec_mask: %08x\n",prec_mask);
+	int* in_key = new int[N];
+	Torus32 b = uniformTorus32_distrib(generator);
+	Torus32* ai = new int[N];
+	uint32_t* aibar = new uint32_t[N];
+	for (int i=0; i<N; i++) {
+	    in_key[i]=(uniformTorus32_distrib(generator)%2==0?1:0);
+	    ai[i]=uniformTorus32_distrib(generator);
+	    aibar[i]=(ai[i]+prec_offset) & prec_mask;
+	}
+	LweSample* res = new_LweSample(params500_1em5);
+	lweCreateKeySwitchKey_fromArray(test->ks,key500,alpha,in_key,N,t,basebit);
+	//we first try one by one
+	lweNoiselessTrivial(res,b,params500_1em5);
+	Torus32 barphi = b;
+	ASSERT_EQ(barphi,res->b);
+	for (int i=0; i<N; i++) {
+	    lweKeySwitchTranslate_fromArray(res, (const LweSample***) test->ks+i,params500_1em5,ai+i,1,t,basebit);
+	    barphi -= aibar[i]*in_key[i];
+	    //verify the decomposition function
+	    //printf( "ai:  %08x\n"
+	    //	    "aib: %08x si: %d\n",ai[i],aibar[i],in_key[i]);
+	    uint32_t dec = 0;
+	    for (int j=0;j<t;j++){
+		const uint32_t aij=(aibar[i]>>(32-(j+1)*basebit)) & (base-1);
+		const uint32_t rec=aij<<(32-(j+1)*basebit);
+		//printf("rec: %08x at j=%d\n",rec,j);
+		dec += rec;
+	    }
+	    ASSERT_EQ(dec,aibar[i]);
+	    ASSERT_NEAR(alpha*alpha*(i+1)*t,res->current_variance,1e-10);
+	    ASSERT_EQ(barphi,res->b);
+	}
+	//now, test it all at once
+	lweNoiselessTrivial(res,b,params500_1em5);
+	lweKeySwitchTranslate_fromArray(res, (const LweSample***) test->ks,params500_1em5,ai,N,t,basebit);
+	ASSERT_NEAR(alpha*alpha*N*t,res->current_variance,1e-10);
+	ASSERT_EQ(barphi,res->b);
+	delete[] in_key;
+	delete[] ai;
+	delete[] aibar;
+	delete_LweKeySwitchKey(test);
+    }
+}


### PR DESCRIPTION
- renamed l into t in the keyswitch function (like in the paper)
- split keyswitch into an array version and a lwe version
- test the array variants

resolves #23.
