### PR TITLE
Add "using namespace std;" to fix compile error in src/test/arithmeti…

### DIFF
--- a/src/test/arithmetic_test.cpp
+++ b/src/test/arithmetic_test.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include <numeric_functions.h>
 
+using namespace std;  
+
 namespace {
 
     // The fixture for testing class Arithmetic.


### PR DESCRIPTION
Fix the following compiler error:  

```
[ 50%] Building CXX object test/CMakeFiles/unittests-fftw.dir/arithmetic_test.cpp.o
/home/xiaonan/Project/tfhe/src/test/arithmetic_test.cpp: In function ‘double {anonymous}::absfrac(double)’:
/home/xiaonan/Project/tfhe/src/test/arithmetic_test.cpp:20:22: error: call of overloaded ‘abs(double)’ is ambiguous
  return abs(d-rint(d));
                      ^
In file included from /usr/include/c++/6.2.1/cstdlib:75:0,
                 from /usr/include/c++/6.2.1/ext/string_conversions.h:41,
                 from /usr/include/c++/6.2.1/bits/basic_string.h:5402,
                 from /usr/include/c++/6.2.1/string:52,
                 from /usr/include/c++/6.2.1/bits/locale_classes.h:40,
                 from /usr/include/c++/6.2.1/bits/ios_base.h:41,
                 from /usr/include/c++/6.2.1/ios:42,
                 from /usr/include/c++/6.2.1/ostream:38,
                 from /usr/include/gtest/gtest.h:55,
                 from /home/xiaonan/Project/tfhe/src/test/arithmetic_test.cpp:1:
/usr/include/stdlib.h:735:12: note: candidate: int abs(int)
 extern int abs (int __x) __THROW __attribute__ ((__const__)) __wur;
            ^~~
In file included from /usr/include/c++/6.2.1/ext/string_conversions.h:41:0,
                 from /usr/include/c++/6.2.1/bits/basic_string.h:5402,
                 from /usr/include/c++/6.2.1/string:52,
                 from /usr/include/c++/6.2.1/bits/locale_classes.h:40,
                 from /usr/include/c++/6.2.1/bits/ios_base.h:41,
                 from /usr/include/c++/6.2.1/ios:42,
                 from /usr/include/c++/6.2.1/ostream:38,
                 from /usr/include/gtest/gtest.h:55,
                 from /home/xiaonan/Project/tfhe/src/test/arithmetic_test.cpp:1:
/usr/include/c++/6.2.1/cstdlib:185:3: note: candidate: __int128 std::abs(__int128)
   abs(__GLIBCXX_TYPE_INT_N_0 __x) { return __x >= 0 ? __x : -__x; }
   ^~~
/usr/include/c++/6.2.1/cstdlib:180:3: note: candidate: long long int std::abs(long long int)
   abs(long long __x) { return __builtin_llabs (__x); }
   ^~~
/usr/include/c++/6.2.1/cstdlib:172:3: note: candidate: long int std::abs(long int)
   abs(long __i) { return __builtin_labs(__i); }
   ^~~
make[2]: *** [test/CMakeFiles/unittests-fftw.dir/build.make:63: test/CMakeFiles/unittests-fftw.dir/arithmetic_test.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1290: test/CMakeFiles/unittests-fftw.dir/all] Error 2
make: *** [Makefile:95: all] Error 2
```

