### PR TITLE
fix relocation errors in assembly code for gcc >= 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,13 @@ clean: build
 distclean:
 	rm -rf build builddtests buildotests; true
 
-test: builddtests buildotests 
+test: builddtests buildotests src/test/googletest/CMakeLists.txt
 	make -j 4 -C builddtests
 	make -j 4 -C buildotests
 	make -j 4 -C builddtests test
 	make -j 4 -C buildotests test
 
-build:
+build: src/test/googletest/CMakeLists.txt
 	mkdir build; cd build; cmake ../src; cd ..
 
 builddtests:
@@ -36,3 +36,7 @@ buildotests:
 	cd $@; cmake ../src ${CMAKE_OTESTS_OPTS}; 
 	cd $@; cmake ../src ${CMAKE_OTESTS_OPTS};
 	cd ..
+
+src/test/googletest/CMakeLists.txt:
+	git submodule init
+	git submodule update

--- a/src/libtfhe/fft_processors/nayuki/fft-x8664-avx-reverse.s
+++ b/src/libtfhe/fft_processors/nayuki/fft-x8664-avx-reverse.s
@@ -104,8 +104,8 @@ size2loop:
 	jb          size2loop
 	
 	/* Size 4 merge (special) */
-	vmovapd     size4negation1, %ymm14
-	vmovapd     size4negation0, %ymm15
+	vmovapd     size4negation1(%rip), %ymm14
+	vmovapd     size4negation0(%rip), %ymm15
 	movq        $0, %rcx  /* Loop counter: Range [0, rdx), step size 4 */
 size4loop:
 	vmovupd     (%rdi,%rcx,8), %ymm0

--- a/src/libtfhe/fft_processors/nayuki/fft-x8664-avx.s
+++ b/src/libtfhe/fft_processors/nayuki/fft-x8664-avx.s
@@ -104,8 +104,8 @@ size2loop:
 	jb          size2loop
 	
 	/* Size 4 merge (special) */
-	vmovapd     size4negation0, %ymm14
-	vmovapd     size4negation1, %ymm15
+	vmovapd     size4negation0(%rip), %ymm14
+	vmovapd     size4negation1(%rip), %ymm15
 	movq        $0, %rcx  /* Loop counter: Range [0, rdx), step size 4 */
 size4loop:
 	vmovupd     (%rdi,%rcx,8), %ymm0

--- a/src/libtfhe/fft_processors/spqlios/Makefile.old
+++ b/src/libtfhe/fft_processors/spqlios/Makefile.old
@@ -1,10 +1,10 @@
 DCFLAGS=-g3 -O0 -Wall
 OCFLAGS=-O2 -DNDEBUG
-CFLAGS=${OCFLAGS}
+CFLAGS=${DCFLAGS}
 
 n:
-	gcc -c ${CFLAGS} spqlios-fft.s	-o spqlios-fft.o
-	gcc -c ${CFLAGS} spqlios-ifft.s	-o spqlios-ifft.o
+	gcc -c ${CFLAGS} spqlios-fft-avx.s	-o spqlios-fft.o
+	gcc -c ${CFLAGS} spqlios-ifft-avx.s	-o spqlios-ifft.o
 	g++ -c ${CFLAGS} spqlios-bench.cpp -o spqlios-bench.o
 	g++ -c ${CFLAGS} spqlios-fft-impl.cpp -o spqlios-fft-impl.o
 	g++  ${CFLAGS} spqlios-fft.o spqlios-ifft.o spqlios-bench.o spqlios-fft-impl.o -o a.out

--- a/src/libtfhe/fft_processors/spqlios/Makefile.old
+++ b/src/libtfhe/fft_processors/spqlios/Makefile.old
@@ -1,6 +1,6 @@
 DCFLAGS=-g3 -O0 -Wall
 OCFLAGS=-O2 -DNDEBUG
-CFLAGS=${DCFLAGS}
+CFLAGS=${DCFLAGS} -fPIC
 
 n:
 	gcc -c ${CFLAGS} spqlios-fft-avx.s	-o spqlios-fft.o

--- a/src/libtfhe/fft_processors/spqlios/spqlios-fft-avx.s
+++ b/src/libtfhe/fft_processors/spqlios/spqlios-fft-avx.s
@@ -68,10 +68,10 @@ fft:
 //	    add4(d1,tmp0,tmp1);
 //	}
 //    }
-	vmovapd     size4negation0, %ymm15
-	vmovapd     size4negation1, %ymm14
-	vmovapd     size4negation2, %ymm13
-	vmovapd     size4negation3, %ymm12
+	vmovapd     size4negation0(%rip), %ymm15
+	vmovapd     size4negation1(%rip), %ymm14
+	vmovapd     size4negation2(%rip), %ymm13
+	vmovapd     size4negation3(%rip), %ymm12
 	
 	movq	$0,%rax	/* rax: block */
 	movq	%rdi,%r10

--- a/src/libtfhe/fft_processors/spqlios/spqlios-fft-fma.s
+++ b/src/libtfhe/fft_processors/spqlios/spqlios-fft-fma.s
@@ -68,10 +68,10 @@ fft:
 //	    add4(d1,tmp0,tmp1);
 //	}
 //    }
-	vmovapd     size4negation0, %ymm15
-	vmovapd     size4negation1, %ymm14
-	vmovapd     size4negation2, %ymm13
-	vmovapd     size4negation3, %ymm12
+	vmovapd     size4negation0(%rip), %ymm15
+	vmovapd     size4negation1(%rip), %ymm14
+	vmovapd     size4negation2(%rip), %ymm13
+	vmovapd     size4negation3(%rip), %ymm12
 	
 	movq	$0,%rax	/* rax: block */
 	movq	%rdi,%r10

--- a/src/libtfhe/fft_processors/spqlios/spqlios-ifft-avx.s
+++ b/src/libtfhe/fft_processors/spqlios/spqlios-ifft-avx.s
@@ -188,10 +188,10 @@ offloop:
     }
 */
     	/* r10 is still = n/4  (constant) */
-	vmovapd     size4negation0, %ymm15
-	vmovapd     size4negation1, %ymm14
-	vmovapd     size4negation2, %ymm13
-	vmovapd     size4negation3, %ymm12
+	vmovapd     size4negation0(%rip), %ymm15
+	vmovapd     size4negation1(%rip), %ymm14
+	vmovapd     size4negation2(%rip), %ymm13
+	vmovapd     size4negation3(%rip), %ymm12
 	movq $0,%rax /* rax (block) */
 	movq %rdi,%r11 /* r11 (are+block) */
 	movq %rsi,%r12 /* r12 (aim+block) */

--- a/src/libtfhe/fft_processors/spqlios/spqlios-ifft-fma.s
+++ b/src/libtfhe/fft_processors/spqlios/spqlios-ifft-fma.s
@@ -184,10 +184,10 @@ offloop:
     }
 */
     	/* r10 is still = n/4  (constant) */
-	vmovapd     size4negation0, %ymm15
-	vmovapd     size4negation1, %ymm14
-	vmovapd     size4negation2, %ymm13
-	vmovapd     size4negation3, %ymm12
+	vmovapd     size4negation0(%rip), %ymm15
+	vmovapd     size4negation1(%rip), %ymm14
+	vmovapd     size4negation2(%rip), %ymm13
+	vmovapd     size4negation3(%rip), %ymm12
 	movq $0,%rax /* rax (block) */
 	movq %rdi,%r11 /* r11 (are+block) */
 	movq %rsi,%r12 /* r12 (aim+block) */


### PR DESCRIPTION
resolves #99 
make all addresses relative to rip in the assembly code