### PR TITLE
Add support for AVX, FMA on OS X

### DIFF
--- a/src/libtfhe/fft_processors/spqlios/lagrangehalfc_impl_avx.s
+++ b/src/libtfhe/fft_processors/spqlios/lagrangehalfc_impl_avx.s
@@ -1,12 +1,18 @@
 	.file	"lagrangehalfc_impl_asm.cpp"
+#if __APPLE__
+	.text
+#else
 	.section	.text.unlikely,"ax",@progbits
+#endif
 .LCOLDB0:
 	.text
 .LHOTB0:
 	.p2align 4,,15
-	.globl	LagrangeHalfCPolynomialMul
-	.type	LagrangeHalfCPolynomialMul, @function
-LagrangeHalfCPolynomialMul:
+	.globl	_LagrangeHalfCPolynomialMul
+#if !__APPLE__
+	.type	_LagrangeHalfCPolynomialMul, @function
+#endif
+_LagrangeHalfCPolynomialMul:
 .LFB7134:
 	.cfi_startproc
 	pushq	%r12
@@ -14,7 +20,7 @@ LagrangeHalfCPolynomialMul:
 	pushq	%r14
 	pushq	%r15
 
-	/* LagrangeHalfCPolynomialMul(HCP* r, HCP* a, HCP* b) */
+	/* _LagrangeHalfCPolynomialMul(HCP* r, HCP* a, HCP* b) */
 	movq	8(%rdi), %rax /* rax: proc */
 	movq	$0,%rcx
 	movl	8(%rax), %ecx /* ecx: Ns2 */
@@ -65,19 +71,29 @@ LagrangeHalfCPolynomialMul:
 	rep ret
 	.cfi_endproc
 .LFE7134:
-	.size	LagrangeHalfCPolynomialMul, .-LagrangeHalfCPolynomialMul
+#if __APPLE__
+	.text
+#else
+	.size	_LagrangeHalfCPolynomialMul, .-_LagrangeHalfCPolynomialMul
 	.section	.text.unlikely
+#endif
 .LCOLDE0:
 	.text
 .LHOTE0:
+#if __APPLE__
+	.text
+#else
 	.section	.text.unlikely
+#endif
 .LCOLDB1:
 	.text
 .LHOTB1:
 	.p2align 4,,15
-	.globl	LagrangeHalfCPolynomialAddMul
-	.type	LagrangeHalfCPolynomialAddMul, @function
-LagrangeHalfCPolynomialAddMul:
+	.globl	_LagrangeHalfCPolynomialAddMul
+#if !__APPLE__
+	.type	_LagrangeHalfCPolynomialAddMul, @function
+#endif
+_LagrangeHalfCPolynomialAddMul:
 .LFB7135:
 	.cfi_startproc
 	pushq	%r12
@@ -85,7 +101,7 @@ LagrangeHalfCPolynomialAddMul:
 	pushq	%r14
 	pushq	%r15
 
-	/* LagrangeHalfCPolynomialAddMul(HCP* r, HCP* a, HCP* b) */
+	/* _LagrangeHalfCPolynomialAddMul(HCP* r, HCP* a, HCP* b) */
 	movq	8(%rdi), %rax /* rax: proc */
 	movq	$0,%rcx
 	movl	8(%rax), %ecx /* ecx: Ns2 */
@@ -140,19 +156,29 @@ LagrangeHalfCPolynomialAddMul:
 	rep ret
 	.cfi_endproc
 .LFE7135:
-	.size	LagrangeHalfCPolynomialAddMul, .-LagrangeHalfCPolynomialAddMul
+#if __APPLE__
+	.text
+#else
+	.size	_LagrangeHalfCPolynomialAddMul, .-_LagrangeHalfCPolynomialAddMul
 	.section	.text.unlikely
+#endif
 .LCOLDE1:
 	.text
 .LHOTE1:
+#if __APPLE__
+	.text
+#else
 	.section	.text.unlikely
+#endif
 .LCOLDB2:
 	.text
 .LHOTB2:
 	.p2align 4,,15
-	.globl	LagrangeHalfCPolynomialSubMul
-	.type	LagrangeHalfCPolynomialSubMul, @function
-LagrangeHalfCPolynomialSubMul:
+	.globl	_LagrangeHalfCPolynomialSubMul
+#if !__APPLE__
+	.type	_LagrangeHalfCPolynomialSubMul, @function
+#endif
+_LagrangeHalfCPolynomialSubMul:
 .LFB7136:
 	.cfi_startproc
 	pushq	%r12
@@ -160,7 +186,7 @@ LagrangeHalfCPolynomialSubMul:
 	pushq	%r14
 	pushq	%r15
 
-	/* LagrangeHalfCPolynomialSubMul(HCP* r, HCP* a, HCP* b) */
+	/* _LagrangeHalfCPolynomialSubMul(HCP* r, HCP* a, HCP* b) */
 	movq	8(%rdi), %rax /* rax: proc */
 	movq	$0,%rcx
 	movl	8(%rax), %ecx /* ecx: Ns2 */
@@ -215,10 +241,16 @@ LagrangeHalfCPolynomialSubMul:
 	rep ret
 	.cfi_endproc
 .LFE7136:
-	.size	LagrangeHalfCPolynomialSubMul, .-LagrangeHalfCPolynomialSubMul
+#if __APPLE__
+	.text
+#else
+	.size	_LagrangeHalfCPolynomialSubMul, .-_LagrangeHalfCPolynomialSubMul
 	.section	.text.unlikely
+#endif
 .LCOLDE2:
 	.text
 .LHOTE2:
 	.ident	"GCC: (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010"
+#if !__APPLE__
 	.section	.note.GNU-stack,"",@progbits
+#endif

--- a/src/libtfhe/fft_processors/spqlios/lagrangehalfc_impl_fma.s
+++ b/src/libtfhe/fft_processors/spqlios/lagrangehalfc_impl_fma.s
@@ -1,12 +1,18 @@
 	.file	"lagrangehalfc_impl_asm.cpp"
+#if __APPLE__
+	.text
+#else
 	.section	.text.unlikely,"ax",@progbits
+#endif
 .LCOLDB0:
 	.text
 .LHOTB0:
 	.p2align 4,,15
-	.globl	LagrangeHalfCPolynomialMul
-	.type	LagrangeHalfCPolynomialMul, @function
-LagrangeHalfCPolynomialMul:
+	.globl	_LagrangeHalfCPolynomialMul
+#if !__APPLE__
+	.type	_LagrangeHalfCPolynomialMul, @function
+#endif
+_LagrangeHalfCPolynomialMul:
 .LFB7134:
 	.cfi_startproc
 	pushq	%r12
@@ -14,7 +20,7 @@ LagrangeHalfCPolynomialMul:
 	pushq	%r14
 	pushq	%r15
 
-	/* LagrangeHalfCPolynomialMul(HCP* r, HCP* a, HCP* b) */
+	/* _LagrangeHalfCPolynomialMul(HCP* r, HCP* a, HCP* b) */
 	movq	8(%rdi), %rax /* rax: proc */
 	movq	$0,%rcx
 	movl	8(%rax), %ecx /* ecx: Ns2 */
@@ -63,19 +69,29 @@ LagrangeHalfCPolynomialMul:
 	rep ret
 	.cfi_endproc
 .LFE7134:
-	.size	LagrangeHalfCPolynomialMul, .-LagrangeHalfCPolynomialMul
+#if __APPLE__
+	.text
+#else
+	.size	_LagrangeHalfCPolynomialMul, .-_LagrangeHalfCPolynomialMul
 	.section	.text.unlikely
+#endif
 .LCOLDE0:
 	.text
 .LHOTE0:
+#if __APPLE__
+	.text
+#else
 	.section	.text.unlikely
+#endif
 .LCOLDB1:
 	.text
 .LHOTB1:
 	.p2align 4,,15
-	.globl	LagrangeHalfCPolynomialAddMul
-	.type	LagrangeHalfCPolynomialAddMul, @function
-LagrangeHalfCPolynomialAddMul:
+	.globl	_LagrangeHalfCPolynomialAddMul
+#if !__APPLE__
+	.type	_LagrangeHalfCPolynomialAddMul, @function
+#endif
+_LagrangeHalfCPolynomialAddMul:
 .LFB7135:
 	.cfi_startproc
 	pushq	%r12
@@ -83,7 +99,7 @@ LagrangeHalfCPolynomialAddMul:
 	pushq	%r14
 	pushq	%r15
 
-	/* LagrangeHalfCPolynomialAddMul(HCP* r, HCP* a, HCP* b) */
+	/* _LagrangeHalfCPolynomialAddMul(HCP* r, HCP* a, HCP* b) */
 	movq	8(%rdi), %rax /* rax: proc */
 	movq	$0,%rcx
 	movl	8(%rax), %ecx /* ecx: Ns2 */
@@ -134,19 +150,29 @@ LagrangeHalfCPolynomialAddMul:
 	rep ret
 	.cfi_endproc
 .LFE7135:
-	.size	LagrangeHalfCPolynomialAddMul, .-LagrangeHalfCPolynomialAddMul
+#if __APPLE__
+	.text
+#else
+	.size	_LagrangeHalfCPolynomialAddMul, .-_LagrangeHalfCPolynomialAddMul
 	.section	.text.unlikely
+#endif
 .LCOLDE1:
 	.text
 .LHOTE1:
+#if __APPLE__
+	.text
+#else
 	.section	.text.unlikely
+#endif
 .LCOLDB2:
 	.text
 .LHOTB2:
 	.p2align 4,,15
-	.globl	LagrangeHalfCPolynomialSubMul
-	.type	LagrangeHalfCPolynomialSubMul, @function
-LagrangeHalfCPolynomialSubMul:
+	.globl	_LagrangeHalfCPolynomialSubMul
+#if !__APPLE__
+	.type	_LagrangeHalfCPolynomialSubMul, @function
+#endif
+_LagrangeHalfCPolynomialSubMul:
 .LFB7136:
 	.cfi_startproc
 	pushq	%r12
@@ -154,7 +180,7 @@ LagrangeHalfCPolynomialSubMul:
 	pushq	%r14
 	pushq	%r15
 
-	/* LagrangeHalfCPolynomialSubMul(HCP* r, HCP* a, HCP* b) */
+	/* _LagrangeHalfCPolynomialSubMul(HCP* r, HCP* a, HCP* b) */
 	movq	8(%rdi), %rax /* rax: proc */
 	movq	$0,%rcx
 	movl	8(%rax), %ecx /* ecx: Ns2 */
@@ -205,10 +231,16 @@ LagrangeHalfCPolynomialSubMul:
 	rep ret
 	.cfi_endproc
 .LFE7136:
-	.size	LagrangeHalfCPolynomialSubMul, .-LagrangeHalfCPolynomialSubMul
+#if __APPLE__
+	.text
+#else
+	.size	_LagrangeHalfCPolynomialSubMul, .-_LagrangeHalfCPolynomialSubMul
 	.section	.text.unlikely
+#endif
 .LCOLDE2:
 	.text
 .LHOTE2:
 	.ident	"GCC: (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010"
+#if !__APPLE__
 	.section	.note.GNU-stack,"",@progbits
+#endif

--- a/src/libtfhe/fft_processors/spqlios/spqlios-fft-avx.s
+++ b/src/libtfhe/fft_processors/spqlios/spqlios-fft-avx.s
@@ -1,16 +1,22 @@
 	.file	"spqlios-fft-avx.s"
+#if __APPLE__
+	.text
+#else
 	.section	.text.unlikely,"ax",@progbits
+#endif
 .LCOLDB0:
 	.text
 .LHOTB0:
 	.p2align 4,,15
-	.globl	fft
-	.type	fft, @function
-fft:
+	.globl	_fft
+#if !__APPLE__
+	.type	_fft, @function
+#endif
+_fft:
 .LFB0:
 	.cfi_startproc
 //c has size n/2
-//void fft(const void* tables, double* c) {
+//void _fft(const void* tables, double* c) {
 
 //    FFT_PRECOMP* fft_tables = (FFT_PRECOMP*) tables;
 //    const int n = fft_tables->n;
@@ -300,11 +306,16 @@ size4negation3: .double +1.0, -1.0, +1.0, -1.0 /* ymm12 */
 
 	.cfi_endproc
 .LFE0:
-	.size	fft, .-fft
+#if __APPLE__
+	.text
+#else
+	.size	_fft, .-_fft
 	.section	.text.unlikely
+#endif
 .LCOLDE0:
 	.text
 .LHOTE0:
 	.ident	"GCC: (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010"
+#if !__APPLE__
 	.section	.note.GNU-stack,"",@progbits
-
+#endif

--- a/src/libtfhe/fft_processors/spqlios/spqlios-fft-fma.s
+++ b/src/libtfhe/fft_processors/spqlios/spqlios-fft-fma.s
@@ -1,16 +1,20 @@
 	.file	"spqlios-fft-avx.s"
+#if !__APPLE__
 	.section	.text.unlikely,"ax",@progbits
+#endif
 .LCOLDB0:
 	.text
 .LHOTB0:
 	.p2align 4,,15
-	.globl	fft
-	.type	fft, @function
-fft:
+	.globl	_fft
+#if !__APPLE__
+	.type	_fft, @function
+#endif
+_fft:
 .LFB0:
 	.cfi_startproc
 //c has size n/2
-//void fft(const void* tables, double* c) {
+//void _fft(const void* tables, double* c) {
 
 //    FFT_PRECOMP* fft_tables = (FFT_PRECOMP*) tables;
 //    const int n = fft_tables->n;
@@ -29,7 +33,7 @@ fft:
 	movq        %rsi, %rdi      /* rdi: base of the real data CONSTANT */
 	
 	/* Load struct FftTables fields */
-	movq         0(%rax), %rdx  /* rdx: n (logical Size of FFT  = a power of 2, must be at least 4) */
+	movq         0(%rax), %rdx  /* rdx: n (logical Size of _fft  = a power of 2, must be at least 4) */
 	movq         8(%rax), %r8   /* r8: Base address of trigonometric tables array (CONSTANT) */
 	
 //    int ns4 = n/4;
@@ -294,11 +298,16 @@ size4negation3: .double +1.0, -1.0, +1.0, -1.0 /* ymm12 */
 
 	.cfi_endproc
 .LFE0:
-	.size	fft, .-fft
+#if __APPLE__
+	.text
+#else
+	.size	_fft, .-_fft
 	.section	.text.unlikely
+#endif
 .LCOLDE0:
 	.text
 .LHOTE0:
 	.ident	"GCC: (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010"
+#if !__APPLE__
 	.section	.note.GNU-stack,"",@progbits
-
+#endif

--- a/src/libtfhe/fft_processors/spqlios/spqlios-ifft-avx.s
+++ b/src/libtfhe/fft_processors/spqlios/spqlios-ifft-avx.s
@@ -1,12 +1,18 @@
 	.file	"spqlios-ifft-avx.s"
+#if __APPLE__
+	.text
+#else
 	.section	.text.unlikely,"ax",@progbits
+#endif
 .LCOLDB0:
 	.text
 .LHOTB0:
 	.p2align 4,,15
-	.globl	ifft
-	.type	ifft, @function
-ifft:
+	.globl	_ifft
+#if !__APPLE__
+	.type	_ifft, @function
+#endif
+_ifft:
 .LFB0:
 	.cfi_startproc
 //typedef struct  {
@@ -14,7 +20,7 @@ ifft:
 //    double* trig_tables;
 //} IFFT_PRECOMP;
 
-/* void ifft(const void *tables, double *real) */
+/* void _ifft(const void *tables, double *real) */
 	/* Save registers */
 	pushq       %r10
 	pushq       %r11
@@ -292,12 +298,17 @@ size4negation3: .double +1.0, -1.0, +1.0, -1.0
 
 	.cfi_endproc
 .LFE0:
-	.size	ifft, .-ifft
+#if __APPLE__
+	.text
+#else
+	.size	_ifft, .-_ifft
 	.section	.text.unlikely
+#endif
 .LCOLDE0:
 	.text
 .LHOTE0:
 	.ident	"GCC: (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010"
+#if !__APPLE__
 	.section	.note.GNU-stack,"",@progbits
-
+#endif
 

--- a/src/libtfhe/fft_processors/spqlios/spqlios-ifft-fma.s
+++ b/src/libtfhe/fft_processors/spqlios/spqlios-ifft-fma.s
@@ -1,12 +1,18 @@
 	.file	"spqlios-ifft-avx.s"
+#if __APPLE__
+	.text
+#else
 	.section	.text.unlikely,"ax",@progbits
+#endif
 .LCOLDB0:
 	.text
 .LHOTB0:
 	.p2align 4,,15
-	.globl	ifft
-	.type	ifft, @function
-ifft:
+	.globl	_ifft
+#if !__APPLE__
+	.type	_ifft, @function
+#endif
+_ifft:
 .LFB0:
 	.cfi_startproc
 //typedef struct  {
@@ -14,7 +20,7 @@ ifft:
 //    double* trig_tables;
 //} IFFT_PRECOMP;
 
-/* void ifft(const void *tables, double *real) */
+/* void _ifft(const void *tables, double *real) */
 	/* Save registers */
 	pushq       %r10
 	pushq       %r11
@@ -284,12 +290,17 @@ size4negation3: .double +1.0, -1.0, +1.0, -1.0
 
 	.cfi_endproc
 .LFE0:
-	.size	ifft, .-ifft
+#if __APPLE__
+	.text
+#else
+	.size	_ifft, .-_ifft
 	.section	.text.unlikely
+#endif
 .LCOLDE0:
 	.text
 .LHOTE0:
 	.ident	"GCC: (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010"
+#if !__APPLE__
 	.section	.note.GNU-stack,"",@progbits
-
+#endif
 


### PR DESCRIPTION
In short, the assembly can be made compatible with Mach-O (the format used by OS X) with a few changes (removing a few directives, basically, and prepending an underscore to global functions).

 * Both the AVX and the FMA version compile successfully on OS X 10.7.5 and CentOS 7.3;
 * a test program compiles correctly on these platforms;
 * a test program with AVX gives the correct result on OS X. I couldn't try FMA on OS X, nor AVX/FMA on CentOS, due to lack of hardware support, but I expect them to work.

Both versions were tested with Clang.