### PR TITLE
Modifs for #138

### DIFF
--- a/libtfhe/core/arithmetic/polynomial.cpp
+++ b/libtfhe/core/arithmetic/polynomial.cpp
@@ -4,49 +4,44 @@
 /**
  * Instantiate Polynomial class for native torus and int types
  */
-EXPLICIT_INSTANTIATE_CLASS(Polynomial, Torus32, TorusUtils<Torus32>::INT_TYPE);
-EXPLICIT_INSTANTIATE_CLASS(Polynomial, Torus64, TorusUtils<Torus64>::INT_TYPE);
-// EXPLICIT_INSTANTIATE_CLASS(Polynomial, Torus32, Torus32);   // native torus and int types are the same => don't need both
-// EXPLICIT_INSTANTIATE_CLASS(Polynomial, Torus64, Torus64);
+EXPLICIT_INSTANTIATE_ALL_PRIMITIVE_TORUS(Polynomial, CoefTypeEnum::Torus);
 
-template<typename TORUS, typename TYPE>
-Polynomial<TORUS,TYPE>::Polynomial(
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator *alloc)
-{
+EXPLICIT_INSTANTIATE_ALL_PRIMITIVE_TORUS(Polynomial, CoefTypeEnum::Integer);
+
+template<typename TORUS, CoefTypeEnum CoefType>
+Polynomial<TORUS, CoefType>::Polynomial(
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator *alloc) {
     coefs = alloc->newArray<TYPE>(params->N);
 }
 
-template<typename TORUS, typename TYPE>
-void Polynomial<TORUS,TYPE>::destroy(
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator *alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::destroy(
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator *alloc) {
     alloc->deleteArray<TYPE>(params->N, coefs);
 }
 
-template<typename TORUS, typename TYPE>
-void Polynomial<TORUS,TYPE>::Clear(
-    Polynomial<TORUS,TYPE> *result,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::Clear(
+        Polynomial<TORUS, CoefType> *result,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     for (int32_t i = 0; i < N; ++i)
         result->coefs[i] = 0;
 }
 
-template<typename TORUS, typename TYPE>
-void Polynomial<TORUS,TYPE>::Copy(
-    Polynomial<TORUS,TYPE> *result,
-    const Polynomial<TORUS,TYPE> *source,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::Copy(
+        Polynomial<TORUS, CoefType> *result,
+        const Polynomial<TORUS, CoefType> *source,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     assert(result != source);
 
     const int32_t N = params->N;
@@ -57,15 +52,14 @@ void Polynomial<TORUS,TYPE>::Copy(
         r[i] = s[i];
 }
 
-template<typename TORUS, typename TYPE>
-void Polynomial<TORUS,TYPE>::Add(
-    Polynomial<TORUS,TYPE> *result,
-    const Polynomial<TORUS,TYPE> *poly1,
-    const Polynomial<TORUS,TYPE> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::Add(
+        Polynomial<TORUS, CoefType> *result,
+        const Polynomial<TORUS, CoefType> *poly1,
+        const Polynomial<TORUS, CoefType> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     assert(result != poly1); //if it fails here, please use addTo
     assert(result != poly2); //if it fails here, please use addTo
 
@@ -78,14 +72,13 @@ void Polynomial<TORUS,TYPE>::Add(
         r[i] = a[i] + b[i];
 }
 
-template<typename TORUS, typename TYPE>
-void Polynomial<TORUS,TYPE>::AddTo(
-    Polynomial<TORUS,TYPE> *result,
-    const Polynomial<TORUS,TYPE> *poly,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::AddTo(
+        Polynomial<TORUS, CoefType> *result,
+        const Polynomial<TORUS, CoefType> *poly,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     const TYPE *s = poly->coefs;
     TYPE *r = result->coefs;
@@ -94,15 +87,14 @@ void Polynomial<TORUS,TYPE>::AddTo(
         r[i] += s[i];
 }
 
-template<typename TORUS, typename TYPE>
-void Polynomial<TORUS,TYPE>::Sub(
-    Polynomial<TORUS,TYPE> *result,
-    const Polynomial<TORUS,TYPE> *poly1,
-    const Polynomial<TORUS,TYPE> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::Sub(
+        Polynomial<TORUS, CoefType> *result,
+        const Polynomial<TORUS, CoefType> *poly1,
+        const Polynomial<TORUS, CoefType> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     assert(result != poly1); //if it fails here, please use addTo
     assert(result != poly2); //if it fails here, please use addTo
 
@@ -115,14 +107,13 @@ void Polynomial<TORUS,TYPE>::Sub(
         r[i] = a[i] - b[i];
 }
 
-template<typename TORUS, typename TYPE>
-void Polynomial<TORUS,TYPE>::SubTo(
-    Polynomial<TORUS,TYPE> *result,
-    const Polynomial<TORUS,TYPE> *poly,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::SubTo(
+        Polynomial<TORUS, CoefType> *result,
+        const Polynomial<TORUS, CoefType> *poly,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     assert(result != poly);
 
     const int32_t N = params->N;
@@ -133,15 +124,14 @@ void Polynomial<TORUS,TYPE>::SubTo(
         r[i] -= s[i];
 }
 
-template<typename TORUS, typename TYPE>
-void Polynomial<TORUS,TYPE>::MulByXaiMinusOne(
-    Polynomial<TORUS,TYPE> *result,
-    const int32_t a,
-    const Polynomial<TORUS,TYPE> *source,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::MulByXaiMinusOne(
+        Polynomial<TORUS, CoefType> *result,
+        const int32_t a,
+        const Polynomial<TORUS, CoefType> *source,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     assert(result != source);
     assert(a >= 0 && a < 2 * N);
@@ -163,15 +153,14 @@ void Polynomial<TORUS,TYPE>::MulByXaiMinusOne(
     }
 }
 
-template<typename TORUS, typename TYPE>
-void Polynomial<TORUS,TYPE>::MulByXai(
-    Polynomial<TORUS,TYPE> *result,
-    const int32_t a,
-    const Polynomial<TORUS,TYPE> *source,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::MulByXai(
+        Polynomial<TORUS, CoefType> *result,
+        const int32_t a,
+        const Polynomial<TORUS, CoefType> *source,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     assert(result != source);
     assert(a >= 0 && a < 2 * N);

--- a/libtfhe/core/arithmetic/polynomial.cpp
+++ b/libtfhe/core/arithmetic/polynomial.cpp
@@ -4,31 +4,33 @@
 /**
  * Instantiate Polynomial class for native torus and int types
  */
-EXPLICIT_INSTANTIATE_ALL_PRIMITIVE_TORUS(Polynomial);
-// EXPLICIT_INSTANTIATE_ALL_PRIMITIVE_INT(Polynomial); // native torus and int types are the same => don't need both
+EXPLICIT_INSTANTIATE_CLASS(Polynomial, Torus32, TorusUtils<Torus32>::INT_TYPE);
+EXPLICIT_INSTANTIATE_CLASS(Polynomial, Torus64, TorusUtils<Torus64>::INT_TYPE);
+// EXPLICIT_INSTANTIATE_CLASS(Polynomial, Torus32, Torus32);   // native torus and int types are the same => don't need both
+// EXPLICIT_INSTANTIATE_CLASS(Polynomial, Torus64, Torus64);
 
-template<typename TYPE>
-Polynomial<TYPE>::Polynomial(
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename TYPE>
+Polynomial<TORUS,TYPE>::Polynomial(
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator *alloc)
 {
     coefs = alloc->newArray<TYPE>(params->N);
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::destroy(
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename TYPE>
+void Polynomial<TORUS,TYPE>::destroy(
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator *alloc)
 {
     alloc->deleteArray<TYPE>(params->N, coefs);
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::Clear(
-    Polynomial<TYPE> *result,
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename TYPE>
+void Polynomial<TORUS,TYPE>::Clear(
+    Polynomial<TORUS,TYPE> *result,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -37,11 +39,11 @@ void Polynomial<TYPE>::Clear(
         result->coefs[i] = 0;
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::Copy(
-    Polynomial<TYPE> *result,
-    const Polynomial<TYPE> *source,
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename TYPE>
+void Polynomial<TORUS,TYPE>::Copy(
+    Polynomial<TORUS,TYPE> *result,
+    const Polynomial<TORUS,TYPE> *source,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -55,12 +57,12 @@ void Polynomial<TYPE>::Copy(
         r[i] = s[i];
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::Add(
-    Polynomial<TYPE> *result,
-    const Polynomial<TYPE> *poly1,
-    const Polynomial<TYPE> *poly2,
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename TYPE>
+void Polynomial<TORUS,TYPE>::Add(
+    Polynomial<TORUS,TYPE> *result,
+    const Polynomial<TORUS,TYPE> *poly1,
+    const Polynomial<TORUS,TYPE> *poly2,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -76,11 +78,11 @@ void Polynomial<TYPE>::Add(
         r[i] = a[i] + b[i];
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::AddTo(
-    Polynomial<TYPE> *result,
-    const Polynomial<TYPE> *poly,
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename TYPE>
+void Polynomial<TORUS,TYPE>::AddTo(
+    Polynomial<TORUS,TYPE> *result,
+    const Polynomial<TORUS,TYPE> *poly,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -92,12 +94,12 @@ void Polynomial<TYPE>::AddTo(
         r[i] += s[i];
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::Sub(
-    Polynomial<TYPE> *result,
-    const Polynomial<TYPE> *poly1,
-    const Polynomial<TYPE> *poly2,
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename TYPE>
+void Polynomial<TORUS,TYPE>::Sub(
+    Polynomial<TORUS,TYPE> *result,
+    const Polynomial<TORUS,TYPE> *poly1,
+    const Polynomial<TORUS,TYPE> *poly2,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -113,11 +115,11 @@ void Polynomial<TYPE>::Sub(
         r[i] = a[i] - b[i];
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::SubTo(
-    Polynomial<TYPE> *result,
-    const Polynomial<TYPE> *poly,
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename TYPE>
+void Polynomial<TORUS,TYPE>::SubTo(
+    Polynomial<TORUS,TYPE> *result,
+    const Polynomial<TORUS,TYPE> *poly,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -131,12 +133,12 @@ void Polynomial<TYPE>::SubTo(
         r[i] -= s[i];
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::MulByXaiMinusOne(
-    Polynomial<TYPE> *result,
+template<typename TORUS, typename TYPE>
+void Polynomial<TORUS,TYPE>::MulByXaiMinusOne(
+    Polynomial<TORUS,TYPE> *result,
     const int32_t a,
-    const Polynomial<TYPE> *source,
-    const PolynomialParams<TYPE> *params,
+    const Polynomial<TORUS,TYPE> *source,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -161,12 +163,12 @@ void Polynomial<TYPE>::MulByXaiMinusOne(
     }
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::MulByXai(
-    Polynomial<TYPE> *result,
+template<typename TORUS, typename TYPE>
+void Polynomial<TORUS,TYPE>::MulByXai(
+    Polynomial<TORUS,TYPE> *result,
     const int32_t a,
-    const Polynomial<TYPE> *source,
-    const PolynomialParams<TYPE> *params,
+    const Polynomial<TORUS,TYPE> *source,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {

--- a/libtfhe/core/arithmetic/polynomial.h
+++ b/libtfhe/core/arithmetic/polynomial.h
@@ -4,19 +4,38 @@
 #include "polynomial_param.h"
 #include "../allocator/allocator.h"
 #include "threadcontext.h"
+#include "torus_utils.h"
 
 #include <cassert>
+
+/**
+ * Polynomial coefficient types enumeration
+ */
+enum CoefTypeEnum {
+    Torus,
+    Integer,
+    Real            // for complex Lagrangian representation?
+};
 
 /**
  * @brief Polynomial class
  *
  * @tparam TORUS torus type
- * @tparam TYPE = TORUS polynomial coefficient type
+ * @tparam CoefType = CoefTypeEnum::Torus type of coefficients
  */
-template<typename TORUS, typename TYPE = TORUS>
-class Polynomial
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+class Polynomial {
 public:
+    static_assert(CoefType == CoefTypeEnum::Torus or CoefType == CoefTypeEnum::Integer,
+                  "Polynomial<TORUS,CoefTypeEnum> only Torus and Integer underlying types are supported for the moment");
+
+    using TYPE = typename
+    std::conditional<
+            CoefType == CoefTypeEnum::Torus,
+            TORUS,
+            typename TorusUtils<TORUS>::INT_TYPE
+    >::type;
+
     TYPE *coefs;
 
     /**
@@ -26,9 +45,10 @@ public:
      * @param context thread execution context
      * @param alloc allocator to use
      */
-    Polynomial(const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator *alloc);
+    Polynomial(
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator *alloc);
 
     /**
      * @brief Destroys inner data of polynomial
@@ -37,9 +57,10 @@ public:
      * @param context thread execution context
      * @param alloc allocator to use
      */
-    void destroy(const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator *alloc);
+    void destroy(
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator *alloc);
 
     /**
      * Static methods
@@ -49,90 +70,90 @@ public:
      * @brief Clear polynomial (zeros coefficients)
      */
     static void Clear(
-        Polynomial<TORUS,TYPE> *result,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+            Polynomial<TORUS, CoefType> *result,
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator alloc);
 
     /**
      * @brief Copy \c source polynomial to \c result
      */
     static void Copy(
-        Polynomial<TORUS,TYPE> *result,
-        const Polynomial<TORUS,TYPE> *source,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+            Polynomial<TORUS, CoefType> *result,
+            const Polynomial<TORUS, CoefType> *source,
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator alloc);
 
     /**
      * @brief Add \c poly1 to \c poly2 and store result in \c result
      *      i.e. result = poly1 + poly2
      */
     static void Add(
-        Polynomial<TORUS,TYPE> *result,
-        const Polynomial<TORUS,TYPE> *poly1,
-        const Polynomial<TORUS,TYPE> *poly2,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+            Polynomial<TORUS, CoefType> *result,
+            const Polynomial<TORUS, CoefType> *poly1,
+            const Polynomial<TORUS, CoefType> *poly2,
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator alloc);
 
     /**
      * @brief Add \c poly polynomial to \c result
      *      i.e. result = result + poly
      */
     static void AddTo(
-        Polynomial<TORUS,TYPE> *result,
-        const Polynomial<TORUS,TYPE> *poly,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+            Polynomial<TORUS, CoefType> *result,
+            const Polynomial<TORUS, CoefType> *poly,
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator alloc);
 
     /**
      * @brief Substract \c poly2 from \c poly1 and store result in \c result
      *      i.e. result = poly1 - poly2
      */
     static void Sub(
-        Polynomial<TORUS,TYPE> *result,
-        const Polynomial<TORUS,TYPE> *poly1,
-        const Polynomial<TORUS,TYPE> *poly2,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+            Polynomial<TORUS, CoefType> *result,
+            const Polynomial<TORUS, CoefType> *poly1,
+            const Polynomial<TORUS, CoefType> *poly2,
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator alloc);
 
     /**
      * @brief Substract \c poly polynomial from \c result
      *      i.e. result = result - poly
      */
     static void SubTo(
-        Polynomial<TORUS,TYPE> *result,
-        const Polynomial<TORUS,TYPE> *poly,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+            Polynomial<TORUS, CoefType> *result,
+            const Polynomial<TORUS, CoefType> *poly,
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator alloc);
 
     /**
      * @brief Multiply polynomial by (X^{a}-1)
      *      i.e. result = (X^{a}-1) * source
      */
     static void MulByXaiMinusOne(
-        Polynomial<TORUS,TYPE> *result,
-        const int32_t a,
-        const Polynomial<TORUS,TYPE> *source,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+            Polynomial<TORUS, CoefType> *result,
+            const int32_t a,
+            const Polynomial<TORUS, CoefType> *source,
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator alloc);
 
     /**
      * @brief Multiply polynomial by X^{a}
      *      i.e. result = (X^{a}-1) * source
      */
     static void MulByXai(
-        Polynomial<TORUS,TYPE> *result,
-        const int32_t a,
-        const Polynomial<TORUS,TYPE> *source,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+            Polynomial<TORUS, CoefType> *result,
+            const int32_t a,
+            const Polynomial<TORUS, CoefType> *source,
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator alloc);
 };
 
 #endif // POLYNOMIAL_H

--- a/libtfhe/core/arithmetic/polynomial.h
+++ b/libtfhe/core/arithmetic/polynomial.h
@@ -7,12 +7,15 @@
 
 #include <cassert>
 
-template<typename TYPE>
+/**
+ * @brief Polynomial class
+ *
+ * @tparam TORUS torus type
+ * @tparam TYPE = TORUS polynomial coefficient type
+ */
+template<typename TORUS, typename TYPE = TORUS>
 class Polynomial
 {
-protected:
-    using ZModuleType = typename PolynomialParams<TYPE>::ZModuleType;
-
 public:
     TYPE *coefs;
 
@@ -23,7 +26,7 @@ public:
      * @param context thread execution context
      * @param alloc allocator to use
      */
-    Polynomial(const PolynomialParams<TYPE> *params,
+    Polynomial(const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator *alloc);
 
@@ -34,7 +37,7 @@ public:
      * @param context thread execution context
      * @param alloc allocator to use
      */
-    void destroy(const PolynomialParams<TYPE> *params,
+    void destroy(const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator *alloc);
 
@@ -46,8 +49,8 @@ public:
      * @brief Clear polynomial (zeros coefficients)
      */
     static void Clear(
-        Polynomial<TYPE> *result,
-        const PolynomialParams<TYPE> *params,
+        Polynomial<TORUS,TYPE> *result,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
@@ -55,9 +58,9 @@ public:
      * @brief Copy \c source polynomial to \c result
      */
     static void Copy(
-        Polynomial<TYPE> *result,
-        const Polynomial<TYPE> *source,
-        const PolynomialParams<TYPE> *params,
+        Polynomial<TORUS,TYPE> *result,
+        const Polynomial<TORUS,TYPE> *source,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
@@ -66,10 +69,10 @@ public:
      *      i.e. result = poly1 + poly2
      */
     static void Add(
-        Polynomial<TYPE> *result,
-        const Polynomial<TYPE> *poly1,
-        const Polynomial<TYPE> *poly2,
-        const PolynomialParams<TYPE> *params,
+        Polynomial<TORUS,TYPE> *result,
+        const Polynomial<TORUS,TYPE> *poly1,
+        const Polynomial<TORUS,TYPE> *poly2,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
@@ -78,9 +81,9 @@ public:
      *      i.e. result = result + poly
      */
     static void AddTo(
-        Polynomial<TYPE> *result,
-        const Polynomial<TYPE> *poly,
-        const PolynomialParams<TYPE> *params,
+        Polynomial<TORUS,TYPE> *result,
+        const Polynomial<TORUS,TYPE> *poly,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
@@ -89,10 +92,10 @@ public:
      *      i.e. result = poly1 - poly2
      */
     static void Sub(
-        Polynomial<TYPE> *result,
-        const Polynomial<TYPE> *poly1,
-        const Polynomial<TYPE> *poly2,
-        const PolynomialParams<TYPE> *params,
+        Polynomial<TORUS,TYPE> *result,
+        const Polynomial<TORUS,TYPE> *poly1,
+        const Polynomial<TORUS,TYPE> *poly2,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
@@ -101,9 +104,9 @@ public:
      *      i.e. result = result - poly
      */
     static void SubTo(
-        Polynomial<TYPE> *result,
-        const Polynomial<TYPE> *poly,
-        const PolynomialParams<TYPE> *params,
+        Polynomial<TORUS,TYPE> *result,
+        const Polynomial<TORUS,TYPE> *poly,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
@@ -112,10 +115,10 @@ public:
      *      i.e. result = (X^{a}-1) * source
      */
     static void MulByXaiMinusOne(
-        Polynomial<TYPE> *result,
+        Polynomial<TORUS,TYPE> *result,
         const int32_t a,
-        const Polynomial<TYPE> *source,
-        const PolynomialParams<TYPE> *params,
+        const Polynomial<TORUS,TYPE> *source,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
@@ -124,10 +127,10 @@ public:
      *      i.e. result = (X^{a}-1) * source
      */
     static void MulByXai(
-        Polynomial<TYPE> *result,
+        Polynomial<TORUS,TYPE> *result,
         const int32_t a,
-        const Polynomial<TYPE> *source,
-        const PolynomialParams<TYPE> *params,
+        const Polynomial<TORUS,TYPE> *source,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 };

--- a/libtfhe/core/arithmetic/polynomial_big.cpp
+++ b/libtfhe/core/arithmetic/polynomial_big.cpp
@@ -3,31 +3,30 @@
 /**
  * Instantiate Polynomial class for big torus and int types
  */
-template struct Polynomial<BigTorus>;
-template struct Polynomial<BigInt>;
-
+template struct Polynomial<BigTorus,BigTorus>;
+template struct Polynomial<BigTorus,BigInt>;
 
 /**
  * Constructor/destructor specialization for BigTorus type
  */
 template<>
-Polynomial<BigTorus>::Polynomial(
+Polynomial<BigTorus,BigTorus>::Polynomial(
     const PolynomialParams<BigTorus> *params,
     TfheThreadContext *context,
     Allocator *alloc)
 {
-    const ZModuleType *const zparams =
+    const ZModuleParams<BigTorus> *const zparams =
         params->zmodule_params;
     coefs = alloc->newArray<BigTorus>(params->N, zparams, alloc);
 }
 
 template<>
-void Polynomial<BigTorus>::destroy(
+void Polynomial<BigTorus,BigTorus>::destroy(
     const PolynomialParams<BigTorus> *params,
     TfheThreadContext *context,
     Allocator *alloc)
 {
-    const ZModuleType *const zparams =
+    const ZModuleParams<BigTorus> *const zparams =
         params->zmodule_params;
     alloc->deleteArray<BigTorus>(params->N, coefs, zparams, alloc);
 }
@@ -36,8 +35,8 @@ void Polynomial<BigTorus>::destroy(
  * Constructor/destructor specialization for BigInt type
  */
 template<>
-Polynomial<BigInt>::Polynomial(
-    const PolynomialParams<BigInt> *params,
+Polynomial<BigTorus,BigInt>::Polynomial(
+    const PolynomialParams<BigTorus> *params,
     TfheThreadContext *context,
     Allocator *alloc)
 {
@@ -45,8 +44,8 @@ Polynomial<BigInt>::Polynomial(
 }
 
 template<>
-void Polynomial<BigInt>::destroy(
-    const PolynomialParams<BigInt> *params,
+void Polynomial<BigTorus,BigInt>::destroy(
+    const PolynomialParams<BigTorus> *params,
     TfheThreadContext *context,
     Allocator *alloc)
 {
@@ -54,47 +53,47 @@ void Polynomial<BigInt>::destroy(
 }
 
 
-template<typename TYPE>
-void Polynomial<TYPE>::Clear(
-    Polynomial<TYPE> *result,
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename COEF_TYPE>
+void Polynomial<TORUS,COEF_TYPE>::Clear(
+    Polynomial<TORUS,COEF_TYPE> *result,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
     const int32_t N = params->N;
-    const ZModuleType *const zparams =
+    const ZModuleParams<TORUS> *const zparams =
         params->zmodule_params;
 
     for (int32_t i = 0; i < N; ++i)
         zero(result->coefs + i, zparams);
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::Copy(
-    Polynomial<TYPE> *result,
-    const Polynomial<TYPE> *source,
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename COEF_TYPE>
+void Polynomial<TORUS,COEF_TYPE>::Copy(
+    Polynomial<TORUS,COEF_TYPE> *result,
+    const Polynomial<TORUS,COEF_TYPE> *source,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
     assert(result != source);
 
     const int32_t N = params->N;
-    const TYPE *s = source->coefs;
-    TYPE *r = result->coefs;
-    const ZModuleType *const zparams =
+    const COEF_TYPE *s = source->coefs;
+    COEF_TYPE *r = result->coefs;
+    const ZModuleParams<TORUS> *const zparams =
         params->zmodule_params;
 
     for (int32_t i = 0; i < N; ++i)
         copy(r+i, s+i, zparams);
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::Add(
-    Polynomial<TYPE> *result,
-    const Polynomial<TYPE> *poly1,
-    const Polynomial<TYPE> *poly2,
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename COEF_TYPE>
+void Polynomial<TORUS,COEF_TYPE>::Add(
+    Polynomial<TORUS,COEF_TYPE> *result,
+    const Polynomial<TORUS,COEF_TYPE> *poly1,
+    const Polynomial<TORUS,COEF_TYPE> *poly2,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -102,40 +101,40 @@ void Polynomial<TYPE>::Add(
     assert(result != poly2); //if it fails here, please use addTo
 
     const int32_t N = params->N;
-    TYPE *r = result->coefs;
-    const TYPE *a = poly1->coefs;
-    const TYPE *b = poly1->coefs;
-    const ZModuleType *const zparams =
+    COEF_TYPE *r = result->coefs;
+    const COEF_TYPE *a = poly1->coefs;
+    const COEF_TYPE *b = poly1->coefs;
+    const ZModuleParams<TORUS> *const zparams =
         params->zmodule_params;
 
     for (int32_t i = 0; i < N; ++i)
         add(r+i, a+i, b+i, zparams);
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::AddTo(
-    Polynomial<TYPE> *result,
-    const Polynomial<TYPE> *poly,
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename COEF_TYPE>
+void Polynomial<TORUS,COEF_TYPE>::AddTo(
+    Polynomial<TORUS,COEF_TYPE> *result,
+    const Polynomial<TORUS,COEF_TYPE> *poly,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
     const int32_t N = params->N;
-    const TYPE *s = poly->coefs;
-    TYPE *r = result->coefs;
-    const ZModuleType *const zparams =
+    const COEF_TYPE *s = poly->coefs;
+    COEF_TYPE *r = result->coefs;
+    const ZModuleParams<TORUS> *const zparams =
         params->zmodule_params;
 
     for (int32_t i = 0; i < N; ++i)
         add(r+i, r+i, s+i, zparams);
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::Sub(
-    Polynomial<TYPE> *result,
-    const Polynomial<TYPE> *poly1,
-    const Polynomial<TYPE> *poly2,
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename COEF_TYPE>
+void Polynomial<TORUS,COEF_TYPE>::Sub(
+    Polynomial<TORUS,COEF_TYPE> *result,
+    const Polynomial<TORUS,COEF_TYPE> *poly1,
+    const Polynomial<TORUS,COEF_TYPE> *poly2,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -143,42 +142,42 @@ void Polynomial<TYPE>::Sub(
     assert(result != poly2); //if it fails here, please use addTo
 
     const int32_t N = params->N;
-    TYPE *r = result->coefs;
-    const TYPE *a = poly1->coefs;
-    const TYPE *b = poly1->coefs;
-    const ZModuleType *const zparams =
+    COEF_TYPE *r = result->coefs;
+    const COEF_TYPE *a = poly1->coefs;
+    const COEF_TYPE *b = poly1->coefs;
+    const ZModuleParams<TORUS> *const zparams =
         params->zmodule_params;
 
     for (int32_t i = 0; i < N; ++i)
         sub(r+i, a+i, b+i, zparams);
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::SubTo(
-    Polynomial<TYPE> *result,
-    const Polynomial<TYPE> *poly,
-    const PolynomialParams<TYPE> *params,
+template<typename TORUS, typename COEF_TYPE>
+void Polynomial<TORUS,COEF_TYPE>::SubTo(
+    Polynomial<TORUS,COEF_TYPE> *result,
+    const Polynomial<TORUS,COEF_TYPE> *poly,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
     assert(result != poly);
 
     const int32_t N = params->N;
-    const TYPE *s = poly->coefs;
-    TYPE *r = result->coefs;
-    const ZModuleType *const zparams =
+    const COEF_TYPE *s = poly->coefs;
+    COEF_TYPE *r = result->coefs;
+    const ZModuleParams<TORUS> *const zparams =
         params->zmodule_params;
 
     for (int32_t i = 0; i < N; ++i)
         sub(r+i, r+i, s+i, zparams);
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::MulByXaiMinusOne(
-    Polynomial<TYPE> *result,
+template<typename TORUS, typename COEF_TYPE>
+void Polynomial<TORUS,COEF_TYPE>::MulByXaiMinusOne(
+    Polynomial<TORUS,COEF_TYPE> *result,
     const int32_t a,
-    const Polynomial<TYPE> *source,
-    const PolynomialParams<TYPE> *params,
+    const Polynomial<TORUS,COEF_TYPE> *source,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -186,9 +185,9 @@ void Polynomial<TYPE>::MulByXaiMinusOne(
     assert(result != source);
     assert(a >= 0 && a < 2 * N);
 
-    TYPE *out = result->coefs;
-    const TYPE *in = source->coefs;
-    const ZModuleType *const zparams =
+    COEF_TYPE *out = result->coefs;
+    const COEF_TYPE *in = source->coefs;
+    const ZModuleParams<TORUS> *const zparams =
         params->zmodule_params;
 
     if (a < N) {
@@ -219,12 +218,12 @@ void Polynomial<TYPE>::MulByXaiMinusOne(
     }
 }
 
-template<typename TYPE>
-void Polynomial<TYPE>::MulByXai(
-    Polynomial<TYPE> *result,
+template<typename TORUS, typename COEF_TYPE>
+void Polynomial<TORUS,COEF_TYPE>::MulByXai(
+    Polynomial<TORUS,COEF_TYPE> *result,
     const int32_t a,
-    const Polynomial<TYPE> *source,
-    const PolynomialParams<TYPE> *params,
+    const Polynomial<TORUS,COEF_TYPE> *source,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -232,9 +231,9 @@ void Polynomial<TYPE>::MulByXai(
     assert(result != source);
     assert(a >= 0 && a < 2 * N);
 
-    TYPE *out = result->coefs;
-    const TYPE *in = source->coefs;
-    const ZModuleType *const zparams =
+    COEF_TYPE *out = result->coefs;
+    const COEF_TYPE *in = source->coefs;
+    const ZModuleParams<TORUS> *const zparams =
         params->zmodule_params;
 
     if (a < N) {

--- a/libtfhe/core/arithmetic/polynomial_big.cpp
+++ b/libtfhe/core/arithmetic/polynomial_big.cpp
@@ -3,31 +3,31 @@
 /**
  * Instantiate Polynomial class for big torus and int types
  */
-template struct Polynomial<BigTorus,BigTorus>;
-template struct Polynomial<BigTorus,BigInt>;
+template
+struct Polynomial<BigTorus, CoefTypeEnum::Torus>;
+template
+struct Polynomial<BigTorus, CoefTypeEnum::Integer>;
 
 /**
  * Constructor/destructor specialization for BigTorus type
  */
 template<>
-Polynomial<BigTorus,BigTorus>::Polynomial(
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator *alloc)
-{
+Polynomial<BigTorus, CoefTypeEnum::Torus>::Polynomial(
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator *alloc) {
     const ZModuleParams<BigTorus> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
     coefs = alloc->newArray<BigTorus>(params->N, zparams, alloc);
 }
 
 template<>
-void Polynomial<BigTorus,BigTorus>::destroy(
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator *alloc)
-{
+void Polynomial<BigTorus, CoefTypeEnum::Torus>::destroy(
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator *alloc) {
     const ZModuleParams<BigTorus> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
     alloc->deleteArray<BigTorus>(params->N, coefs, zparams, alloc);
 }
 
@@ -35,227 +35,217 @@ void Polynomial<BigTorus,BigTorus>::destroy(
  * Constructor/destructor specialization for BigInt type
  */
 template<>
-Polynomial<BigTorus,BigInt>::Polynomial(
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator *alloc)
-{
+Polynomial<BigTorus, CoefTypeEnum::Integer>::Polynomial(
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator *alloc) {
     coefs = alloc->newArray<BigInt>(params->N);
 }
 
 template<>
-void Polynomial<BigTorus,BigInt>::destroy(
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator *alloc)
-{
+void Polynomial<BigTorus, CoefTypeEnum::Integer>::destroy(
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator *alloc) {
     alloc->deleteArray<BigInt>(params->N, coefs);
 }
 
 
-template<typename TORUS, typename COEF_TYPE>
-void Polynomial<TORUS,COEF_TYPE>::Clear(
-    Polynomial<TORUS,COEF_TYPE> *result,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::Clear(
+        Polynomial<TORUS, CoefType> *result,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     const ZModuleParams<TORUS> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     for (int32_t i = 0; i < N; ++i)
         zero(result->coefs + i, zparams);
 }
 
-template<typename TORUS, typename COEF_TYPE>
-void Polynomial<TORUS,COEF_TYPE>::Copy(
-    Polynomial<TORUS,COEF_TYPE> *result,
-    const Polynomial<TORUS,COEF_TYPE> *source,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::Copy(
+        Polynomial<TORUS, CoefType> *result,
+        const Polynomial<TORUS, CoefType> *source,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     assert(result != source);
 
     const int32_t N = params->N;
-    const COEF_TYPE *s = source->coefs;
-    COEF_TYPE *r = result->coefs;
+    const TYPE *s = source->coefs;
+    TYPE *r = result->coefs;
     const ZModuleParams<TORUS> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     for (int32_t i = 0; i < N; ++i)
-        copy(r+i, s+i, zparams);
+        copy(r + i, s + i, zparams);
 }
 
-template<typename TORUS, typename COEF_TYPE>
-void Polynomial<TORUS,COEF_TYPE>::Add(
-    Polynomial<TORUS,COEF_TYPE> *result,
-    const Polynomial<TORUS,COEF_TYPE> *poly1,
-    const Polynomial<TORUS,COEF_TYPE> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::Add(
+        Polynomial<TORUS, CoefType> *result,
+        const Polynomial<TORUS, CoefType> *poly1,
+        const Polynomial<TORUS, CoefType> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     assert(result != poly1); //if it fails here, please use addTo
     assert(result != poly2); //if it fails here, please use addTo
 
     const int32_t N = params->N;
-    COEF_TYPE *r = result->coefs;
-    const COEF_TYPE *a = poly1->coefs;
-    const COEF_TYPE *b = poly1->coefs;
+    TYPE *r = result->coefs;
+    const TYPE *a = poly1->coefs;
+    const TYPE *b = poly1->coefs;
     const ZModuleParams<TORUS> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     for (int32_t i = 0; i < N; ++i)
-        add(r+i, a+i, b+i, zparams);
+        add(r + i, a + i, b + i, zparams);
 }
 
-template<typename TORUS, typename COEF_TYPE>
-void Polynomial<TORUS,COEF_TYPE>::AddTo(
-    Polynomial<TORUS,COEF_TYPE> *result,
-    const Polynomial<TORUS,COEF_TYPE> *poly,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::AddTo(
+        Polynomial<TORUS, CoefType> *result,
+        const Polynomial<TORUS, CoefType> *poly,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
-    const COEF_TYPE *s = poly->coefs;
-    COEF_TYPE *r = result->coefs;
+    const TYPE *s = poly->coefs;
+    TYPE *r = result->coefs;
     const ZModuleParams<TORUS> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     for (int32_t i = 0; i < N; ++i)
-        add(r+i, r+i, s+i, zparams);
+        add(r + i, r + i, s + i, zparams);
 }
 
-template<typename TORUS, typename COEF_TYPE>
-void Polynomial<TORUS,COEF_TYPE>::Sub(
-    Polynomial<TORUS,COEF_TYPE> *result,
-    const Polynomial<TORUS,COEF_TYPE> *poly1,
-    const Polynomial<TORUS,COEF_TYPE> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::Sub(
+        Polynomial<TORUS, CoefType> *result,
+        const Polynomial<TORUS, CoefType> *poly1,
+        const Polynomial<TORUS, CoefType> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     assert(result != poly1); //if it fails here, please use addTo
     assert(result != poly2); //if it fails here, please use addTo
 
     const int32_t N = params->N;
-    COEF_TYPE *r = result->coefs;
-    const COEF_TYPE *a = poly1->coefs;
-    const COEF_TYPE *b = poly1->coefs;
+    TYPE *r = result->coefs;
+    const TYPE *a = poly1->coefs;
+    const TYPE *b = poly1->coefs;
     const ZModuleParams<TORUS> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     for (int32_t i = 0; i < N; ++i)
-        sub(r+i, a+i, b+i, zparams);
+        sub(r + i, a + i, b + i, zparams);
 }
 
-template<typename TORUS, typename COEF_TYPE>
-void Polynomial<TORUS,COEF_TYPE>::SubTo(
-    Polynomial<TORUS,COEF_TYPE> *result,
-    const Polynomial<TORUS,COEF_TYPE> *poly,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::SubTo(
+        Polynomial<TORUS, CoefType> *result,
+        const Polynomial<TORUS, CoefType> *poly,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     assert(result != poly);
 
     const int32_t N = params->N;
-    const COEF_TYPE *s = poly->coefs;
-    COEF_TYPE *r = result->coefs;
+    const TYPE *s = poly->coefs;
+    TYPE *r = result->coefs;
     const ZModuleParams<TORUS> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     for (int32_t i = 0; i < N; ++i)
-        sub(r+i, r+i, s+i, zparams);
+        sub(r + i, r + i, s + i, zparams);
 }
 
-template<typename TORUS, typename COEF_TYPE>
-void Polynomial<TORUS,COEF_TYPE>::MulByXaiMinusOne(
-    Polynomial<TORUS,COEF_TYPE> *result,
-    const int32_t a,
-    const Polynomial<TORUS,COEF_TYPE> *source,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::MulByXaiMinusOne(
+        Polynomial<TORUS, CoefType> *result,
+        const int32_t a,
+        const Polynomial<TORUS, CoefType> *source,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     assert(result != source);
     assert(a >= 0 && a < 2 * N);
 
-    COEF_TYPE *out = result->coefs;
-    const COEF_TYPE *in = source->coefs;
+    TYPE *out = result->coefs;
+    const TYPE *in = source->coefs;
     const ZModuleParams<TORUS> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     if (a < N) {
         // i-a < 0
         for (int32_t i = 0; i < a; i++) {
-            copy(out+i, in+(i - a + N), zparams);
-            neg(out+i, out+i, zparams);
-            sub(out+i, out+i, in+i, zparams);
+            copy(out + i, in + (i - a + N), zparams);
+            neg(out + i, out + i, zparams);
+            sub(out + i, out + i, in + i, zparams);
         }
         // N > i-a >= 0
         for (int32_t i = a; i < N; i++) {
-            copy(out+i, in+(i - a), zparams);
-            sub(out+i, out+i, in+i, zparams);
+            copy(out + i, in + (i - a), zparams);
+            sub(out + i, out + i, in + i, zparams);
         }
     } else {
         const int32_t aa = a - N;
         //sur que i-a<0
         for (int32_t i = 0; i < aa; i++) {
-            copy(out+i, in+(i - aa + N), zparams);
-            sub(out+i, out+i, in+i, zparams);
+            copy(out + i, in + (i - aa + N), zparams);
+            sub(out + i, out + i, in + i, zparams);
         }
         //sur que N>i-a>=0
         for (int32_t i = aa; i < N; i++) {
-            copy(out+i, in+(i - aa), zparams);
-            neg(out+i, out+i, zparams);
-            sub(out+i, out+i, in+i, zparams);
+            copy(out + i, in + (i - aa), zparams);
+            neg(out + i, out + i, zparams);
+            sub(out + i, out + i, in + i, zparams);
         }
     }
 }
 
-template<typename TORUS, typename COEF_TYPE>
-void Polynomial<TORUS,COEF_TYPE>::MulByXai(
-    Polynomial<TORUS,COEF_TYPE> *result,
-    const int32_t a,
-    const Polynomial<TORUS,COEF_TYPE> *source,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+template<typename TORUS, CoefTypeEnum CoefType>
+void Polynomial<TORUS, CoefType>::MulByXai(
+        Polynomial<TORUS, CoefType> *result,
+        const int32_t a,
+        const Polynomial<TORUS, CoefType> *source,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     assert(result != source);
     assert(a >= 0 && a < 2 * N);
 
-    COEF_TYPE *out = result->coefs;
-    const COEF_TYPE *in = source->coefs;
+    TYPE *out = result->coefs;
+    const TYPE *in = source->coefs;
     const ZModuleParams<TORUS> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     if (a < N) {
         //sur que i-a<0
         for (int32_t i = 0; i < a; i++) {
-            copy(out+i, in+(i - a + N), zparams);
-            neg(out+i, out+i, zparams);
+            copy(out + i, in + (i - a + N), zparams);
+            neg(out + i, out + i, zparams);
         }
         //sur que N>i-a>=0
         for (int32_t i = a; i < N; i++) {
-            copy(out+i, in+(i - a), zparams);
+            copy(out + i, in + (i - a), zparams);
         }
     } else {
         const int32_t aa = a - N;
         //sur que i-a<0
         for (int32_t i = 0; i < aa; i++) {
-            copy(out+i, in+(i - aa + N), zparams);
+            copy(out + i, in + (i - aa + N), zparams);
         }
         //sur que N>i-a>=0
         for (int32_t i = aa; i < N; i++) {
-            copy(out+i, in+(i - a), zparams);
-            neg(out+i, out+i, zparams);
+            copy(out + i, in + (i - a), zparams);
+            neg(out + i, out + i, zparams);
         }
     }
 }

--- a/libtfhe/core/arithmetic/polynomial_int.cpp
+++ b/libtfhe/core/arithmetic/polynomial_int.cpp
@@ -14,11 +14,10 @@ EXPLICIT_INSTANTIATE_ALL_PRIMITIVE_TORUS(IntPolynomial);
 // Euclidean norm of an IntPolynomial
 template<typename TORUS>
 double IntPolynomial<TORUS>::Norm2sq(
-    const IntPolynomial<TORUS> *poly,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        const IntPolynomial<TORUS> *poly,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     double norm = 0;
 
@@ -32,12 +31,11 @@ double IntPolynomial<TORUS>::Norm2sq(
 // Infinity norm of the distance between two IntPolynomial
 template<typename TORUS>
 double IntPolynomial<TORUS>::NormInftyDist(
-    const IntPolynomial<TORUS> *poly1,
-    const IntPolynomial<TORUS> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        const IntPolynomial<TORUS> *poly1,
+        const IntPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     double norm = 0;
 

--- a/libtfhe/core/arithmetic/polynomial_int.cpp
+++ b/libtfhe/core/arithmetic/polynomial_int.cpp
@@ -3,20 +3,19 @@
 #include <cassert>
 
 /**
- * Instantiate IntPolynomial class for available int types
+ * Instantiate IntPolynomial class for available torus types
  */
-EXPLICIT_INSTANTIATE_ALL_PRIMITIVE_INT(IntPolynomial);
-
+EXPLICIT_INSTANTIATE_ALL_PRIMITIVE_TORUS(IntPolynomial);
 
 /**
  * Integer polynomial functions
  */
 
 // Euclidean norm of an IntPolynomial
-template<typename INT_TYPE>
-double IntPolynomial<INT_TYPE>::Norm2sq(
-    const IntPolynomial<INT_TYPE> *poly,
-    const PolynomialParams<INT_TYPE> *params,
+template<typename TORUS>
+double IntPolynomial<TORUS>::Norm2sq(
+    const IntPolynomial<TORUS> *poly,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -31,11 +30,11 @@ double IntPolynomial<INT_TYPE>::Norm2sq(
 }
 
 // Infinity norm of the distance between two IntPolynomial
-template<typename INT_TYPE>
-double IntPolynomial<INT_TYPE>::NormInftyDist(
-    const IntPolynomial<INT_TYPE> *poly1,
-    const IntPolynomial<INT_TYPE> *poly2,
-    const PolynomialParams<INT_TYPE> *params,
+template<typename TORUS>
+double IntPolynomial<TORUS>::NormInftyDist(
+    const IntPolynomial<TORUS> *poly1,
+    const IntPolynomial<TORUS> *poly2,
+    const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {

--- a/libtfhe/core/arithmetic/polynomial_int.h
+++ b/libtfhe/core/arithmetic/polynomial_int.h
@@ -5,18 +5,36 @@
 #include "torus.h"
 #include "polynomial.h"
 
+namespace tfhe_core_intern {
+    /**
+     * @brief Helper class to automatically choose coefficient types for IntPolynomial class.
+     *  In this case there is no need to have IntPolynomial with 2 template parameters.
+     */
+    template<typename TORUS, typename INT_TYPE = typename TorusUtils<TORUS>::INT_TYPE>
+    struct IntPolynomial_ : public Polynomial<TORUS, INT_TYPE> {
+        IntPolynomial_(
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator *alloc) : Polynomial<TORUS,INT_TYPE>(params, context, alloc) { }
+
+        void destroy(
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator *alloc)
+        {
+            destroy(params, context, alloc);
+        }
+    };
+};
+
 /**
  * @brief Polynomial with integer coefficients
  *
- * @tparam INT_TYPE integer type of coefficients
+ * @tparam TORUS torus type
  */
-template<typename INT_TYPE>
-class IntPolynomial : public Polynomial<INT_TYPE>
+template<typename TORUS>
+class IntPolynomial : public tfhe_core_intern::IntPolynomial_<TORUS>
 {
-    static_assert(std::is_same<INT_TYPE, BigInt>::value or
-        (std::is_integral<INT_TYPE>::value and std::is_signed<INT_TYPE>::value),
-        "IntPolynomial<T> defined only for native signed integer types and BigInt");
-
 public:
     /**
      * @brief Constructs a polynomial with given parameters
@@ -26,9 +44,9 @@ public:
      * @param alloc allocator to use
      */
     IntPolynomial(
-        const PolynomialParams<INT_TYPE> *params,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
-        Allocator *alloc) : Polynomial<INT_TYPE>(params, context, alloc) { }
+        Allocator *alloc) : tfhe_core_intern::IntPolynomial_<TORUS>(params, context, alloc) { }
 
     /**
      * @brief Destroys inner data of polynomial
@@ -38,7 +56,7 @@ public:
      * @param alloc allocator to use
      */
     void destroy(
-        const PolynomialParams<INT_TYPE> *params,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator *alloc)
     {
@@ -52,15 +70,15 @@ public:
      */
 public:
     /** Euclidean norm of an Integer Polynomial */
-    static double Norm2sq(const IntPolynomial<INT_TYPE> *poly,
-        const PolynomialParams<INT_TYPE> *params,
+    static double Norm2sq(const IntPolynomial<TORUS> *poly,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
     /** Infinity norm of the distance between two integer polynomials */
-    static double NormInftyDist(const IntPolynomial<INT_TYPE> *poly1,
-        const IntPolynomial<INT_TYPE> *poly2,
-        const PolynomialParams<INT_TYPE> *params,
+    static double NormInftyDist(const IntPolynomial<TORUS> *poly1,
+        const IntPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 };

--- a/libtfhe/core/arithmetic/polynomial_int.h
+++ b/libtfhe/core/arithmetic/polynomial_int.h
@@ -5,36 +5,13 @@
 #include "torus.h"
 #include "polynomial.h"
 
-namespace tfhe_core_intern {
-    /**
-     * @brief Helper class to automatically choose coefficient types for IntPolynomial class.
-     *  In this case there is no need to have IntPolynomial with 2 template parameters.
-     */
-    template<typename TORUS, typename INT_TYPE = typename TorusUtils<TORUS>::INT_TYPE>
-    struct IntPolynomial_ : public Polynomial<TORUS, INT_TYPE> {
-        IntPolynomial_(
-            const PolynomialParams<TORUS> *params,
-            TfheThreadContext *context,
-            Allocator *alloc) : Polynomial<TORUS,INT_TYPE>(params, context, alloc) { }
-
-        void destroy(
-            const PolynomialParams<TORUS> *params,
-            TfheThreadContext *context,
-            Allocator *alloc)
-        {
-            destroy(params, context, alloc);
-        }
-    };
-};
-
 /**
  * @brief Polynomial with integer coefficients
  *
  * @tparam TORUS torus type
  */
 template<typename TORUS>
-class IntPolynomial : public tfhe_core_intern::IntPolynomial_<TORUS>
-{
+class IntPolynomial : public Polynomial<TORUS, CoefTypeEnum::Integer> {
 public:
     /**
      * @brief Constructs a polynomial with given parameters
@@ -44,9 +21,9 @@ public:
      * @param alloc allocator to use
      */
     IntPolynomial(
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator *alloc) : tfhe_core_intern::IntPolynomial_<TORUS>(params, context, alloc) { }
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator *alloc) : Polynomial<TORUS, CoefTypeEnum::Integer>(params, context, alloc) {}
 
     /**
      * @brief Destroys inner data of polynomial
@@ -56,10 +33,9 @@ public:
      * @param alloc allocator to use
      */
     void destroy(
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator *alloc)
-    {
+            const PolynomialParams<TORUS> *params,
+            TfheThreadContext *context,
+            Allocator *alloc) {
         destroy(params, context, alloc);
     }
 
@@ -71,16 +47,16 @@ public:
 public:
     /** Euclidean norm of an Integer Polynomial */
     static double Norm2sq(const IntPolynomial<TORUS> *poly,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+                          const PolynomialParams<TORUS> *params,
+                          TfheThreadContext *context,
+                          Allocator alloc);
 
     /** Infinity norm of the distance between two integer polynomials */
     static double NormInftyDist(const IntPolynomial<TORUS> *poly1,
-        const IntPolynomial<TORUS> *poly2,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+                                const IntPolynomial<TORUS> *poly2,
+                                const PolynomialParams<TORUS> *params,
+                                TfheThreadContext *context,
+                                Allocator alloc);
 };
 
 #endif // POLYNOMIAL_INT_H

--- a/libtfhe/core/arithmetic/polynomial_int_big.cpp
+++ b/libtfhe/core/arithmetic/polynomial_int_big.cpp
@@ -5,16 +5,16 @@
 /**
  * Instantiate IntPolynomial class for big int type
  */
-template struct IntPolynomial<BigTorus>;
+template
+class IntPolynomial<BigTorus>;
 
 // Euclidean norm of an IntPolynomial
 template<>
 double IntPolynomial<BigTorus>::Norm2sq(
-    const IntPolynomial<BigTorus> *poly,
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        const IntPolynomial<BigTorus> *poly,
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     abort(); //not implemented yet
     return 0;
 }
@@ -22,12 +22,11 @@ double IntPolynomial<BigTorus>::Norm2sq(
 // Infinity norm of the distance between two IntPolynomial
 template<>
 double IntPolynomial<BigTorus>::NormInftyDist(
-    const IntPolynomial<BigTorus> *poly1,
-    const IntPolynomial<BigTorus> *poly2,
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        const IntPolynomial<BigTorus> *poly1,
+        const IntPolynomial<BigTorus> *poly2,
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     abort(); //not implemented yet
     return 0;
 }

--- a/libtfhe/core/arithmetic/polynomial_int_big.cpp
+++ b/libtfhe/core/arithmetic/polynomial_int_big.cpp
@@ -5,13 +5,13 @@
 /**
  * Instantiate IntPolynomial class for big int type
  */
-template struct IntPolynomial<BigInt>;
+template struct IntPolynomial<BigTorus>;
 
 // Euclidean norm of an IntPolynomial
 template<>
-double IntPolynomial<BigInt>::Norm2sq(
-    const IntPolynomial<BigInt> *poly,
-    const PolynomialParams<BigInt> *params,
+double IntPolynomial<BigTorus>::Norm2sq(
+    const IntPolynomial<BigTorus> *poly,
+    const PolynomialParams<BigTorus> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -21,10 +21,10 @@ double IntPolynomial<BigInt>::Norm2sq(
 
 // Infinity norm of the distance between two IntPolynomial
 template<>
-double IntPolynomial<BigInt>::NormInftyDist(
-    const IntPolynomial<BigInt> *poly1,
-    const IntPolynomial<BigInt> *poly2,
-    const PolynomialParams<BigInt> *params,
+double IntPolynomial<BigTorus>::NormInftyDist(
+    const IntPolynomial<BigTorus> *poly1,
+    const IntPolynomial<BigTorus> *poly2,
+    const PolynomialParams<BigTorus> *params,
     TfheThreadContext *context,
     Allocator alloc)
 {

--- a/libtfhe/core/arithmetic/polynomial_param.h
+++ b/libtfhe/core/arithmetic/polynomial_param.h
@@ -11,18 +11,13 @@
 /**
  * @brief Polynomial parameters class
  *
- * @tparam COEF_TYPE polynomial coefficient type
+ * @tparam TORUS torus type
  */
-template<typename COEF_TYPE>
+template<typename TORUS>
 class PolynomialParams {
-private:
-    using TORUS = typename std::conditional<std::is_same<COEF_TYPE, BigInt>::value, BigTorus, COEF_TYPE>::type;
-
 public:
     int32_t N;
-
-    typedef ZModuleParams<TORUS> ZModuleType;
-    ZModuleType* zmodule_params;
+    ZModuleParams<TORUS> *zmodule_params;
 };
 
 #endif //POLYNOMIAL_PARAM_H

--- a/libtfhe/core/arithmetic/polynomial_torus.cpp
+++ b/libtfhe/core/arithmetic/polynomial_torus.cpp
@@ -115,7 +115,7 @@ double TorusPolynomial<TORUS>::NormInftyDist(
 {
     const int32_t N = params->N;
     double norm = 0;
-    const typename PolynomialParams<TORUS>::ZModuleType *const zparams =
+    const ZModuleParams<TORUS> *const zparams =
         params->zmodule_params;
 
     // Max between the coefficients of abs(poly1-poly2)
@@ -133,7 +133,7 @@ void TorusPolynomial<TORUS>::MultNaive_plain_aux(
     const INT_TYPE *__restrict poly1,
     const TORUS *__restrict poly2,
     const int32_t N,
-    const ZModuleType *const zparams,
+    const ZModuleParams<TORUS> *const zparams,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -163,7 +163,7 @@ void TorusPolynomial<TORUS>::MultNaive_aux(
     const INT_TYPE *__restrict poly1,
     const TORUS *__restrict poly2,
     const int32_t N,
-    const ZModuleType *const zparams,
+    const ZModuleParams<TORUS> *const zparams,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -189,7 +189,7 @@ void TorusPolynomial<TORUS>::MultNaive_aux(
 template<typename TORUS>
 void TorusPolynomial<TORUS>::MultNaive(
     TorusPolynomial<TORUS> *result,
-    const IntPolynomial<INT_TYPE> *poly1,
+    const IntPolynomial<TORUS> *poly1,
     const TorusPolynomial<TORUS> *poly2,
     const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
@@ -198,7 +198,7 @@ void TorusPolynomial<TORUS>::MultNaive(
     assert(result != poly2);
 
     const int32_t N = params->N;
-    const typename PolynomialParams<TORUS>::ZModuleType *const zparams =
+    const ZModuleParams<TORUS> *const zparams =
         params->zmodule_params;
 
     TorusPolynomial<TORUS>::MultNaive_aux(result->coefs, poly1->coefs,
@@ -221,7 +221,7 @@ void TorusPolynomial<TORUS>::Karatsuba_aux(
     const TORUS *B,
     const int32_t size,
     const char *buf,
-    const ZModuleType *const zparams,
+    const ZModuleParams<TORUS> *const zparams,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -267,7 +267,7 @@ void TorusPolynomial<TORUS>::Karatsuba_aux(
 template<typename TORUS>
 void TorusPolynomial<TORUS>::MultKaratsuba(
     TorusPolynomial<TORUS> *result,
-    const IntPolynomial<INT_TYPE> *poly1,
+    const IntPolynomial<TORUS> *poly1,
     const TorusPolynomial<TORUS> *poly2,
     const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
@@ -276,7 +276,7 @@ void TorusPolynomial<TORUS>::MultKaratsuba(
     const int32_t N = params->N;
     TORUS *R = new TORUS[2 * N - 1];
     char *buf = new char[4 * N * sizeof(TORUS)]; //that's large enough to store every tmp variables (2*2*N*4) TODO: see if there is unused memory (before generic torus byte cnt was 16*N)
-    const typename PolynomialParams<TORUS>::ZModuleType *const zparams =
+    const ZModuleParams<TORUS> *const zparams =
         params->zmodule_params;
 
     // Karatsuba
@@ -295,7 +295,7 @@ void TorusPolynomial<TORUS>::MultKaratsuba(
 template<typename TORUS>
 void TorusPolynomial<TORUS>::AddMulRKaratsuba(
     TorusPolynomial<TORUS> *result,
-    const IntPolynomial<INT_TYPE> *poly1,
+    const IntPolynomial<TORUS> *poly1,
     const TorusPolynomial<TORUS> *poly2,
     const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
@@ -304,7 +304,7 @@ void TorusPolynomial<TORUS>::AddMulRKaratsuba(
     const int32_t N = params->N;
     TORUS *R = new TORUS[2 * N - 1];
     char *buf = new char[16 * N]; //that's large enough to store every tmp variables (2*2*N*4)
-    const typename PolynomialParams<TORUS>::ZModuleType *const zparams =
+    const ZModuleParams<TORUS> *const zparams =
         params->zmodule_params;
 
     // Karatsuba
@@ -323,7 +323,7 @@ void TorusPolynomial<TORUS>::AddMulRKaratsuba(
 template<typename TORUS>
 void TorusPolynomial<TORUS>::SubMulRKaratsuba(
     TorusPolynomial<TORUS> *result,
-    const IntPolynomial<INT_TYPE> *poly1,
+    const IntPolynomial<TORUS> *poly1,
     const TorusPolynomial<TORUS> *poly2,
     const PolynomialParams<TORUS> *params,
     TfheThreadContext *context,
@@ -332,7 +332,7 @@ void TorusPolynomial<TORUS>::SubMulRKaratsuba(
     const int32_t N = params->N;
     TORUS *R = new TORUS[2 * N - 1];
     char *buf = new char[16 * N]; //that's large enough to store every tmp variables (2*2*N*4)
-    const typename PolynomialParams<TORUS>::ZModuleType *const zparams =
+    const ZModuleParams<TORUS> *const zparams =
         params->zmodule_params;
 
     // Karatsuba

--- a/libtfhe/core/arithmetic/polynomial_torus.cpp
+++ b/libtfhe/core/arithmetic/polynomial_torus.cpp
@@ -13,11 +13,10 @@ EXPLICIT_INSTANTIATE_ALL_PRIMITIVE_TORUS(TorusPolynomial);
 // TorusPolynomial = random
 template<typename TORUS>
 void TorusPolynomial<TORUS>::Uniform(
-    TorusPolynomial<TORUS> *result,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<TORUS> *result,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     TORUS *x = result->coefs;
 
@@ -28,14 +27,13 @@ void TorusPolynomial<TORUS>::Uniform(
 // TorusPolynomial + p*TorusPolynomial
 template<typename TORUS>
 void TorusPolynomial<TORUS>::AddMulZ(
-    TorusPolynomial<TORUS> *result,
-    const TorusPolynomial<TORUS> *poly1,
-    const INT_TYPE *p,
-    const TorusPolynomial<TORUS> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<TORUS> *result,
+        const TorusPolynomial<TORUS> *poly1,
+        const INT_TYPE *p,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     assert(result != poly1); //if it fails here, please use AddMulZTo
     TORUS *r = result->coefs;
@@ -49,13 +47,12 @@ void TorusPolynomial<TORUS>::AddMulZ(
 // TorusPolynomial += p*TorusPolynomial
 template<typename TORUS>
 void TorusPolynomial<TORUS>::AddMulZTo(
-    TorusPolynomial<TORUS> *result,
-    const INT_TYPE *p,
-    const TorusPolynomial<TORUS> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<TORUS> *result,
+        const INT_TYPE *p,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     TORUS *r = result->coefs;
     const TORUS *b = poly2->coefs;
@@ -67,14 +64,13 @@ void TorusPolynomial<TORUS>::AddMulZTo(
 // TorusPolynomial - p*TorusPolynomial
 template<typename TORUS>
 void TorusPolynomial<TORUS>::SubMulZ(
-    TorusPolynomial<TORUS> *result,
-    const TorusPolynomial<TORUS> *poly1,
-    const INT_TYPE *p,
-    const TorusPolynomial<TORUS> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<TORUS> *result,
+        const TorusPolynomial<TORUS> *poly1,
+        const INT_TYPE *p,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     assert(result != poly1); //if it fails here, please use SubMulZTo
     TORUS *r = result->coefs;
@@ -88,13 +84,12 @@ void TorusPolynomial<TORUS>::SubMulZ(
 // TorusPolynomial -= p*TorusPolynomial
 template<typename TORUS>
 void TorusPolynomial<TORUS>::SubMulZTo(
-    TorusPolynomial<TORUS> *result,
-    const INT_TYPE *p,
-    const TorusPolynomial<TORUS> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<TORUS> *result,
+        const INT_TYPE *p,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     TORUS *r = result->coefs;
     const TORUS *b = poly2->coefs;
@@ -107,16 +102,15 @@ void TorusPolynomial<TORUS>::SubMulZTo(
 // Infinity norm of the distance between two TorusPolynomial
 template<typename TORUS>
 double TorusPolynomial<TORUS>::NormInftyDist(
-    const TorusPolynomial<TORUS> *poly1,
-    const TorusPolynomial<TORUS> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        const TorusPolynomial<TORUS> *poly1,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     double norm = 0;
     const ZModuleParams<TORUS> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     // Max between the coefficients of abs(poly1-poly2)
     for (int32_t i = 0; i < N; ++i) {
@@ -129,14 +123,13 @@ double TorusPolynomial<TORUS>::NormInftyDist(
 
 template<typename TORUS>
 void TorusPolynomial<TORUS>::MultNaive_plain_aux(
-    TORUS *__restrict result,
-    const INT_TYPE *__restrict poly1,
-    const TORUS *__restrict poly2,
-    const int32_t N,
-    const ZModuleParams<TORUS> *const zparams,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TORUS *__restrict result,
+        const INT_TYPE *__restrict poly1,
+        const TORUS *__restrict poly2,
+        const int32_t N,
+        const ZModuleParams<TORUS> *const zparams,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t _2Nm1 = 2 * N - 1;
     TORUS ri;
 
@@ -159,14 +152,13 @@ void TorusPolynomial<TORUS>::MultNaive_plain_aux(
 
 template<typename TORUS>
 void TorusPolynomial<TORUS>::MultNaive_aux(
-    TORUS *__restrict result,
-    const INT_TYPE *__restrict poly1,
-    const TORUS *__restrict poly2,
-    const int32_t N,
-    const ZModuleParams<TORUS> *const zparams,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TORUS *__restrict result,
+        const INT_TYPE *__restrict poly1,
+        const TORUS *__restrict poly2,
+        const int32_t N,
+        const ZModuleParams<TORUS> *const zparams,
+        TfheThreadContext *context,
+        Allocator alloc) {
     TORUS ri;
 
     for (int32_t i = 0; i < N; i++) {
@@ -188,21 +180,20 @@ void TorusPolynomial<TORUS>::MultNaive_aux(
  */
 template<typename TORUS>
 void TorusPolynomial<TORUS>::MultNaive(
-    TorusPolynomial<TORUS> *result,
-    const IntPolynomial<TORUS> *poly1,
-    const TorusPolynomial<TORUS> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<TORUS> *result,
+        const IntPolynomial<TORUS> *poly1,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     assert(result != poly2);
 
     const int32_t N = params->N;
     const ZModuleParams<TORUS> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     TorusPolynomial<TORUS>::MultNaive_aux(result->coefs, poly1->coefs,
-        poly2->coefs, N, zparams, context, alloc);
+                                          poly2->coefs, N, zparams, context, alloc);
 }
 
 /**
@@ -216,22 +207,20 @@ void TorusPolynomial<TORUS>::MultNaive(
 // R of size = 2*size-1
 template<typename TORUS>
 void TorusPolynomial<TORUS>::Karatsuba_aux(
-    TORUS *R,
-    const INT_TYPE *A,
-    const TORUS *B,
-    const int32_t size,
-    const char *buf,
-    const ZModuleParams<TORUS> *const zparams,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TORUS *R,
+        const INT_TYPE *A,
+        const TORUS *B,
+        const int32_t size,
+        const char *buf,
+        const ZModuleParams<TORUS> *const zparams,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t h = size / 2;
     const int32_t sm1 = size - 1;
 
     //we stop the karatsuba recursion at h=4, because on my machine,
     //it seems to be optimal
-    if (h <= 4)
-    {
+    if (h <= 4) {
         TorusPolynomial<TORUS>::MultNaive_plain_aux(R, A, B, size, zparams, context, alloc);
         return;
     }
@@ -266,18 +255,18 @@ void TorusPolynomial<TORUS>::Karatsuba_aux(
 // poly1, poly2 and result are polynomials mod X^N+1
 template<typename TORUS>
 void TorusPolynomial<TORUS>::MultKaratsuba(
-    TorusPolynomial<TORUS> *result,
-    const IntPolynomial<TORUS> *poly1,
-    const TorusPolynomial<TORUS> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<TORUS> *result,
+        const IntPolynomial<TORUS> *poly1,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     TORUS *R = new TORUS[2 * N - 1];
-    char *buf = new char[4 * N * sizeof(TORUS)]; //that's large enough to store every tmp variables (2*2*N*4) TODO: see if there is unused memory (before generic torus byte cnt was 16*N)
+    char *buf = new char[4 * N *
+                         sizeof(TORUS)]; //that's large enough to store every tmp variables (2*2*N*4) TODO: see if there is unused memory (before generic torus byte cnt was 16*N)
     const ZModuleParams<TORUS> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     // Karatsuba
     Karatsuba_aux(R, poly1->coefs, poly2->coefs, N, buf, zparams, context, alloc);
@@ -294,18 +283,17 @@ void TorusPolynomial<TORUS>::MultKaratsuba(
 // poly1, poly2 and result are polynomials mod X^N+1
 template<typename TORUS>
 void TorusPolynomial<TORUS>::AddMulRKaratsuba(
-    TorusPolynomial<TORUS> *result,
-    const IntPolynomial<TORUS> *poly1,
-    const TorusPolynomial<TORUS> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<TORUS> *result,
+        const IntPolynomial<TORUS> *poly1,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     TORUS *R = new TORUS[2 * N - 1];
     char *buf = new char[16 * N]; //that's large enough to store every tmp variables (2*2*N*4)
     const ZModuleParams<TORUS> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     // Karatsuba
     Karatsuba_aux(R, poly1->coefs, poly2->coefs, N, buf, zparams, context, alloc);
@@ -322,18 +310,17 @@ void TorusPolynomial<TORUS>::AddMulRKaratsuba(
 // poly1, poly2 and result are polynomials mod X^N+1
 template<typename TORUS>
 void TorusPolynomial<TORUS>::SubMulRKaratsuba(
-    TorusPolynomial<TORUS> *result,
-    const IntPolynomial<TORUS> *poly1,
-    const TorusPolynomial<TORUS> *poly2,
-    const PolynomialParams<TORUS> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<TORUS> *result,
+        const IntPolynomial<TORUS> *poly1,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     TORUS *R = new TORUS[2 * N - 1];
     char *buf = new char[16 * N]; //that's large enough to store every tmp variables (2*2*N*4)
     const ZModuleParams<TORUS> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     // Karatsuba
     Karatsuba_aux(R, poly1->coefs, poly2->coefs, N, buf, zparams, context, alloc);

--- a/libtfhe/core/arithmetic/polynomial_torus.h
+++ b/libtfhe/core/arithmetic/polynomial_torus.h
@@ -9,8 +9,7 @@
  * @tparam TORUS type of coefficients
  */
 template<typename TORUS>
-class TorusPolynomial : public Polynomial<TORUS>
-{
+class TorusPolynomial : public Polynomial<TORUS, CoefTypeEnum::Torus> {
     using INT_TYPE = typename TorusUtils<TORUS>::INT_TYPE;
 
 public:
@@ -22,8 +21,8 @@ public:
      * @param alloc allocator to use
      */
     TorusPolynomial(const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator *alloc) : Polynomial<TORUS>(params, context, alloc) { }
+                    TfheThreadContext *context,
+                    Allocator *alloc) : Polynomial<TORUS, CoefTypeEnum::Torus>(params, context, alloc) {}
 
     /**
      * @brief Destroys inner data of polynomial
@@ -33,9 +32,8 @@ public:
      * @param alloc allocator to use
      */
     void destroy(const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator *alloc)
-    {
+                 TfheThreadContext *context,
+                 Allocator *alloc) {
         destroy(params, context, alloc);
     }
 
@@ -52,12 +50,12 @@ private:
      * poly2 and result must point to different memory areas
      */
     static void MultNaive_plain_aux(TORUS *__restrict result,
-        const INT_TYPE *__restrict poly1,
-        const TORUS *__restrict poly2,
-        const int32_t N,
-        const ZModuleParams<TORUS> *const zparams,
-        TfheThreadContext *context,
-        Allocator alloc);
+                                    const INT_TYPE *__restrict poly1,
+                                    const TORUS *__restrict poly2,
+                                    const int32_t N,
+                                    const ZModuleParams<TORUS> *const zparams,
+                                    TfheThreadContext *context,
+                                    Allocator alloc);
 
     /**
      * This function multiplies two polynomials in Z[X] and T[X] of degree < N
@@ -66,12 +64,12 @@ private:
      * poly2 and result must point to different memory areas
      */
     static void MultNaive_aux(TORUS *__restrict result,
-        const INT_TYPE *__restrict poly1,
-        const TORUS *__restrict poly2,
-        const int32_t N,
-        const ZModuleParams<TORUS> *const zparams,
-        TfheThreadContext *context,
-        Allocator alloc);
+                              const INT_TYPE *__restrict poly1,
+                              const TORUS *__restrict poly2,
+                              const int32_t N,
+                              const ZModuleParams<TORUS> *const zparams,
+                              TfheThreadContext *context,
+                              Allocator alloc);
 
     /**
      *  This function multiplies two polynomials in Z[X] and T[X] of degree < N
@@ -79,61 +77,61 @@ private:
      *  @param buf a memory area of length at least 4*N*sizeof(TORUS)
      */
     static void Karatsuba_aux(TORUS *R,
-        const INT_TYPE *A,
-        const TORUS *B,
-        const int32_t size,
-        const char *buf,
-        const ZModuleParams<TORUS> *const zparams,
-        TfheThreadContext *context,
-        Allocator alloc);
+                              const INT_TYPE *A,
+                              const TORUS *B,
+                              const int32_t size,
+                              const char *buf,
+                              const ZModuleParams<TORUS> *const zparams,
+                              TfheThreadContext *context,
+                              Allocator alloc);
 
 public:
     /**  @brief TorusPolynomial = random */
     static void Uniform(TorusPolynomial<TORUS> *result,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+                        const PolynomialParams<TORUS> *params,
+                        TfheThreadContext *context,
+                        Allocator alloc);
 
     /**  TorusPolynomial + p*TorusPolynomial */
     static void AddMulZ(TorusPolynomial<TORUS> *result,
-        const TorusPolynomial<TORUS> *poly1,
-        const INT_TYPE *p,
-        const TorusPolynomial<TORUS> *poly2,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+                        const TorusPolynomial<TORUS> *poly1,
+                        const INT_TYPE *p,
+                        const TorusPolynomial<TORUS> *poly2,
+                        const PolynomialParams<TORUS> *params,
+                        TfheThreadContext *context,
+                        Allocator alloc);
 
     /**  TorusPolynomial += p*TorusPolynomial */
     static void AddMulZTo(TorusPolynomial<TORUS> *result,
-        const INT_TYPE *p,
-        const TorusPolynomial<TORUS> *poly2,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+                          const INT_TYPE *p,
+                          const TorusPolynomial<TORUS> *poly2,
+                          const PolynomialParams<TORUS> *params,
+                          TfheThreadContext *context,
+                          Allocator alloc);
 
     /**  TorusPolynomial - p*TorusPolynomial */
     static void SubMulZ(TorusPolynomial<TORUS> *result,
-        const TorusPolynomial<TORUS> *poly1,
-        const INT_TYPE *p,
-        const TorusPolynomial<TORUS> *poly2,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+                        const TorusPolynomial<TORUS> *poly1,
+                        const INT_TYPE *p,
+                        const TorusPolynomial<TORUS> *poly2,
+                        const PolynomialParams<TORUS> *params,
+                        TfheThreadContext *context,
+                        Allocator alloc);
 
     /**  TorusPolynomial -= p*TorusPolynomial */
     static void SubMulZTo(TorusPolynomial<TORUS> *result,
-        const INT_TYPE *p,
-        const TorusPolynomial<TORUS> *poly2,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+                          const INT_TYPE *p,
+                          const TorusPolynomial<TORUS> *poly2,
+                          const PolynomialParams<TORUS> *params,
+                          TfheThreadContext *context,
+                          Allocator alloc);
 
     /**  Infinity norm of the distance between two torus polynomials */
     static double NormInftyDist(const TorusPolynomial<TORUS> *poly1,
-        const TorusPolynomial<TORUS> *poly2,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+                                const TorusPolynomial<TORUS> *poly2,
+                                const PolynomialParams<TORUS> *params,
+                                TfheThreadContext *context,
+                                Allocator alloc);
 
     /**
      * This is the naive external multiplication of an integer polynomial
@@ -141,11 +139,11 @@ public:
      * result as the karatsuba or fft version, but should be slower)
      */
     static void MultNaive(TorusPolynomial<TORUS> *result,
-        const IntPolynomial<TORUS> *poly1,
-        const TorusPolynomial<TORUS> *poly2,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+                          const IntPolynomial<TORUS> *poly1,
+                          const TorusPolynomial<TORUS> *poly2,
+                          const PolynomialParams<TORUS> *params,
+                          TfheThreadContext *context,
+                          Allocator alloc);
 
     /**
      * This function multiplies 2 polynomials (an integer poly and a torus poly)
@@ -154,11 +152,11 @@ public:
      * behaviour is unpredictable
      */
     static void MultKaratsuba(TorusPolynomial<TORUS> *result,
-        const IntPolynomial<TORUS> *poly1,
-        const TorusPolynomial<TORUS> *poly2,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+                              const IntPolynomial<TORUS> *poly1,
+                              const TorusPolynomial<TORUS> *poly2,
+                              const PolynomialParams<TORUS> *params,
+                              TfheThreadContext *context,
+                              Allocator alloc);
 
     /**
      * result += poly1 * poly2 (via Karatsuba)
@@ -166,11 +164,11 @@ public:
      * behaviour is unpredictable
      */
     static void AddMulRKaratsuba(TorusPolynomial<TORUS> *result,
-        const IntPolynomial<TORUS> *poly1,
-        const TorusPolynomial<TORUS> *poly2,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+                                 const IntPolynomial<TORUS> *poly1,
+                                 const TorusPolynomial<TORUS> *poly2,
+                                 const PolynomialParams<TORUS> *params,
+                                 TfheThreadContext *context,
+                                 Allocator alloc);
 
     /**
      * result -= poly1 * poly2 (via karatsuba)
@@ -178,11 +176,11 @@ public:
      * behaviour is unpredictable
      */
     static void SubMulRKaratsuba(TorusPolynomial<TORUS> *result,
-        const IntPolynomial<TORUS> *poly1,
-        const TorusPolynomial<TORUS> *poly2,
-        const PolynomialParams<TORUS> *params,
-        TfheThreadContext *context,
-        Allocator alloc);
+                                 const IntPolynomial<TORUS> *poly1,
+                                 const TorusPolynomial<TORUS> *poly2,
+                                 const PolynomialParams<TORUS> *params,
+                                 TfheThreadContext *context,
+                                 Allocator alloc);
 };
 
 #endif

--- a/libtfhe/core/arithmetic/polynomial_torus.h
+++ b/libtfhe/core/arithmetic/polynomial_torus.h
@@ -6,13 +6,12 @@
 /**
  * @brief Polynomial with torus coefficients
  *
- * @tparam TORUS_TYPE type of coefficients
+ * @tparam TORUS type of coefficients
  */
-template<typename TORUS_TYPE>
-class TorusPolynomial : public Polynomial<TORUS_TYPE>
+template<typename TORUS>
+class TorusPolynomial : public Polynomial<TORUS>
 {
-    using INT_TYPE = typename TorusUtils<TORUS_TYPE>::INT_TYPE;
-    using ZModuleType = typename Polynomial<TORUS_TYPE>::ZModuleType;
+    using INT_TYPE = typename TorusUtils<TORUS>::INT_TYPE;
 
 public:
     /**
@@ -22,9 +21,9 @@ public:
      * @param context thread execution context
      * @param alloc allocator to use
      */
-    TorusPolynomial(const PolynomialParams<TORUS_TYPE> *params,
+    TorusPolynomial(const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
-        Allocator *alloc) : Polynomial<TORUS_TYPE>(params, context, alloc) { }
+        Allocator *alloc) : Polynomial<TORUS>(params, context, alloc) { }
 
     /**
      * @brief Destroys inner data of polynomial
@@ -33,7 +32,7 @@ public:
      * @param context thread execution context
      * @param alloc allocator to use
      */
-    void destroy(const PolynomialParams<TORUS_TYPE> *params,
+    void destroy(const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator *alloc)
     {
@@ -52,11 +51,11 @@ private:
      * The result is a polynomial of T[X] of degree < 2N-1
      * poly2 and result must point to different memory areas
      */
-    static void MultNaive_plain_aux(TORUS_TYPE *__restrict result,
+    static void MultNaive_plain_aux(TORUS *__restrict result,
         const INT_TYPE *__restrict poly1,
-        const TORUS_TYPE *__restrict poly2,
+        const TORUS *__restrict poly2,
         const int32_t N,
-        const ZModuleType *const zparams,
+        const ZModuleParams<TORUS> *const zparams,
         TfheThreadContext *context,
         Allocator alloc);
 
@@ -66,73 +65,73 @@ private:
      * The result is a polynomial of T[X] of degree < N
      * poly2 and result must point to different memory areas
      */
-    static void MultNaive_aux(TORUS_TYPE *__restrict result,
+    static void MultNaive_aux(TORUS *__restrict result,
         const INT_TYPE *__restrict poly1,
-        const TORUS_TYPE *__restrict poly2,
+        const TORUS *__restrict poly2,
         const int32_t N,
-        const ZModuleType *const zparams,
+        const ZModuleParams<TORUS> *const zparams,
         TfheThreadContext *context,
         Allocator alloc);
 
     /**
      *  This function multiplies two polynomials in Z[X] and T[X] of degree < N
      *  The result is a polynomial of T[X] of degree < 2N-1
-     *  @param buf a memory area of length at least 4*N*sizeof(TORUS_TYPE)
+     *  @param buf a memory area of length at least 4*N*sizeof(TORUS)
      */
-    static void Karatsuba_aux(TORUS_TYPE *R,
+    static void Karatsuba_aux(TORUS *R,
         const INT_TYPE *A,
-        const TORUS_TYPE *B,
+        const TORUS *B,
         const int32_t size,
         const char *buf,
-        const ZModuleType *const zparams,
+        const ZModuleParams<TORUS> *const zparams,
         TfheThreadContext *context,
         Allocator alloc);
 
 public:
     /**  @brief TorusPolynomial = random */
-    static void Uniform(TorusPolynomial<TORUS_TYPE> *result,
-        const PolynomialParams<TORUS_TYPE> *params,
+    static void Uniform(TorusPolynomial<TORUS> *result,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
     /**  TorusPolynomial + p*TorusPolynomial */
-    static void AddMulZ(TorusPolynomial<TORUS_TYPE> *result,
-        const TorusPolynomial<TORUS_TYPE> *poly1,
+    static void AddMulZ(TorusPolynomial<TORUS> *result,
+        const TorusPolynomial<TORUS> *poly1,
         const INT_TYPE *p,
-        const TorusPolynomial<TORUS_TYPE> *poly2,
-        const PolynomialParams<TORUS_TYPE> *params,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
     /**  TorusPolynomial += p*TorusPolynomial */
-    static void AddMulZTo(TorusPolynomial<TORUS_TYPE> *result,
+    static void AddMulZTo(TorusPolynomial<TORUS> *result,
         const INT_TYPE *p,
-        const TorusPolynomial<TORUS_TYPE> *poly2,
-        const PolynomialParams<TORUS_TYPE> *params,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
     /**  TorusPolynomial - p*TorusPolynomial */
-    static void SubMulZ(TorusPolynomial<TORUS_TYPE> *result,
-        const TorusPolynomial<TORUS_TYPE> *poly1,
+    static void SubMulZ(TorusPolynomial<TORUS> *result,
+        const TorusPolynomial<TORUS> *poly1,
         const INT_TYPE *p,
-        const TorusPolynomial<TORUS_TYPE> *poly2,
-        const PolynomialParams<TORUS_TYPE> *params,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
     /**  TorusPolynomial -= p*TorusPolynomial */
-    static void SubMulZTo(TorusPolynomial<TORUS_TYPE> *result,
+    static void SubMulZTo(TorusPolynomial<TORUS> *result,
         const INT_TYPE *p,
-        const TorusPolynomial<TORUS_TYPE> *poly2,
-        const PolynomialParams<TORUS_TYPE> *params,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
     /**  Infinity norm of the distance between two torus polynomials */
-    static double NormInftyDist(const TorusPolynomial<TORUS_TYPE> *poly1,
-        const TorusPolynomial<TORUS_TYPE> *poly2,
-        const PolynomialParams<TORUS_TYPE> *params,
+    static double NormInftyDist(const TorusPolynomial<TORUS> *poly1,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
@@ -141,10 +140,10 @@ public:
      * with a torus polynomial. (this function should yield exactly the same
      * result as the karatsuba or fft version, but should be slower)
      */
-    static void MultNaive(TorusPolynomial<TORUS_TYPE> *result,
-        const IntPolynomial<INT_TYPE> *poly1,
-        const TorusPolynomial<TORUS_TYPE> *poly2,
-        const PolynomialParams<TORUS_TYPE> *params,
+    static void MultNaive(TorusPolynomial<TORUS> *result,
+        const IntPolynomial<TORUS> *poly1,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
@@ -154,10 +153,10 @@ public:
      * WARNING: N must be a power of 2 to use this function. Else, the
      * behaviour is unpredictable
      */
-    static void MultKaratsuba(TorusPolynomial<TORUS_TYPE> *result,
-        const IntPolynomial<INT_TYPE> *poly1,
-        const TorusPolynomial<TORUS_TYPE> *poly2,
-        const PolynomialParams<TORUS_TYPE> *params,
+    static void MultKaratsuba(TorusPolynomial<TORUS> *result,
+        const IntPolynomial<TORUS> *poly1,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
@@ -166,10 +165,10 @@ public:
      * WARNING: N must be a power of 2 to use this function. Else, the
      * behaviour is unpredictable
      */
-    static void AddMulRKaratsuba(TorusPolynomial<TORUS_TYPE> *result,
-        const IntPolynomial<INT_TYPE> *poly1,
-        const TorusPolynomial<TORUS_TYPE> *poly2,
-        const PolynomialParams<TORUS_TYPE> *params,
+    static void AddMulRKaratsuba(TorusPolynomial<TORUS> *result,
+        const IntPolynomial<TORUS> *poly1,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 
@@ -178,10 +177,10 @@ public:
      * WARNING: N must be a power of 2 to use this function. Else, the
      * behaviour is unpredictable
      */
-    static void SubMulRKaratsuba(TorusPolynomial<TORUS_TYPE> *result,
-        const IntPolynomial<INT_TYPE> *poly1,
-        const TorusPolynomial<TORUS_TYPE> *poly2,
-        const PolynomialParams<TORUS_TYPE> *params,
+    static void SubMulRKaratsuba(TorusPolynomial<TORUS> *result,
+        const IntPolynomial<TORUS> *poly1,
+        const TorusPolynomial<TORUS> *poly2,
+        const PolynomialParams<TORUS> *params,
         TfheThreadContext *context,
         Allocator alloc);
 };

--- a/libtfhe/core/arithmetic/polynomial_torus_big.cpp
+++ b/libtfhe/core/arithmetic/polynomial_torus_big.cpp
@@ -5,116 +5,111 @@
 /**
  * Instantiate TorusPolynomial class for big torus type
  */
-template struct TorusPolynomial<BigTorus>;
+template
+class TorusPolynomial<BigTorus>;
 
 // TorusPolynomial = random
 template<>
 void TorusPolynomial<BigTorus>::Uniform(
-    TorusPolynomial<BigTorus> *result,
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<BigTorus> *result,
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     abort(); //not implemented yet
 }
 
 // TorusPolynomial + p*TorusPolynomial
 template<>
 void TorusPolynomial<BigTorus>::AddMulZ(
-    TorusPolynomial<BigTorus> *result,
-    const TorusPolynomial<BigTorus> *poly1,
-    const INT_TYPE *p,
-    const TorusPolynomial<BigTorus> *poly2,
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<BigTorus> *result,
+        const TorusPolynomial<BigTorus> *poly1,
+        const INT_TYPE *p,
+        const TorusPolynomial<BigTorus> *poly2,
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     assert(result != poly1); //if it fails here, please use AddMulZTo
     BigTorus *r = result->coefs;
     const BigTorus *a = poly1->coefs;
     const BigTorus *b = poly2->coefs;
     const ZModuleParams<BigTorus> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     BigTorus *t = alloc.newObject<BigTorus>(zparams, &alloc);
     for (int32_t i = 0; i < N; ++i) {
-        copy(t, b+i, zparams);
+        copy(t, b + i, zparams);
         mul(t, p, t, zparams, alloc);
-        add(r+i, a+i, t, zparams);
+        add(r + i, a + i, t, zparams);
     }
 }
 
 // TorusPolynomial += p*TorusPolynomial
 template<>
 void TorusPolynomial<BigTorus>::AddMulZTo(
-    TorusPolynomial<BigTorus> *result,
-    const INT_TYPE *p,
-    const TorusPolynomial<BigTorus> *poly2,
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<BigTorus> *result,
+        const INT_TYPE *p,
+        const TorusPolynomial<BigTorus> *poly2,
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     TorusPolynomial<BigTorus>::AddMulZ(result, result, p, poly2, params, context, alloc);
 }
 
 // TorusPolynomial - p*TorusPolynomial
 template<>
 void TorusPolynomial<BigTorus>::SubMulZ(
-    TorusPolynomial<BigTorus> *result,
-    const TorusPolynomial<BigTorus> *poly1,
-    const INT_TYPE *p,
-    const TorusPolynomial<BigTorus> *poly2,
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<BigTorus> *result,
+        const TorusPolynomial<BigTorus> *poly1,
+        const INT_TYPE *p,
+        const TorusPolynomial<BigTorus> *poly2,
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     assert(result != poly1); //if it fails here, please use AddMulZTo
     BigTorus *r = result->coefs;
     const BigTorus *a = poly1->coefs;
     const BigTorus *b = poly2->coefs;
     const ZModuleParams<BigTorus> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     BigTorus *t = alloc.newObject<BigTorus>(zparams, &alloc);
     for (int32_t i = 0; i < N; ++i) {
-        copy(t, b+i, zparams);
+        copy(t, b + i, zparams);
         mul(t, p, t, zparams, alloc);
-        sub(r+i, a+i, t, zparams);
+        sub(r + i, a + i, t, zparams);
     }
 }
 
 // TorusPolynomial -= p*TorusPolynomial
 template<>
 void TorusPolynomial<BigTorus>::SubMulZTo(
-    TorusPolynomial<BigTorus> *result,
-    const INT_TYPE *p,
-    const TorusPolynomial<BigTorus> *poly2,
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<BigTorus> *result,
+        const INT_TYPE *p,
+        const TorusPolynomial<BigTorus> *poly2,
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     TorusPolynomial<BigTorus>::SubMulZ(result, result, p, poly2, params, context, alloc);
 }
 
 // Infinity norm of the distance between two TorusPolynomial
 template<>
 double TorusPolynomial<BigTorus>::NormInftyDist(
-    const TorusPolynomial<BigTorus> *poly1,
-    const TorusPolynomial<BigTorus> *poly2,
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        const TorusPolynomial<BigTorus> *poly1,
+        const TorusPolynomial<BigTorus> *poly2,
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t N = params->N;
     double norm = 0;
     const ZModuleParams<BigTorus> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     // Max between the coefficients of abs(poly1-poly2)
     for (int32_t i = 0; i < N; ++i) {
-        double r = TorusUtils<BigTorus>::normInftyDist(poly1->coefs+i, poly2->coefs+i, zparams);
+        double r = TorusUtils<BigTorus>::normInftyDist(poly1->coefs + i, poly2->coefs + i, zparams);
         if (r > norm) { norm = r; }
     }
     return norm;
@@ -123,31 +118,30 @@ double TorusPolynomial<BigTorus>::NormInftyDist(
 
 template<>
 void TorusPolynomial<BigTorus>::MultNaive_plain_aux(
-    BigTorus *__restrict result,
-    const INT_TYPE *__restrict poly1,
-    const BigTorus *__restrict poly2,
-    const int32_t N,
-    const ZModuleParams<BigTorus> *const zparams,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        BigTorus *__restrict result,
+        const INT_TYPE *__restrict poly1,
+        const BigTorus *__restrict poly2,
+        const int32_t N,
+        const ZModuleParams<BigTorus> *const zparams,
+        TfheThreadContext *context,
+        Allocator alloc) {
     const int32_t _2Nm1 = 2 * N - 1;
     BigTorus *ti = alloc.newObject<BigTorus>(zparams, &alloc);
 
     for (int32_t i = 0; i < N; i++) {
-        BigTorus *ri = result+i;
+        BigTorus *ri = result + i;
         zero(ri, zparams);
         for (int32_t j = 0; j <= i; j++) {
-            mul(ti, poly1+j, poly2+(i-j), zparams, alloc);
+            mul(ti, poly1 + j, poly2 + (i - j), zparams, alloc);
             add(ri, ri, ti, zparams);
         }
     }
 
     for (int32_t i = N; i < _2Nm1; i++) {
-        BigTorus *ri = result+i;
+        BigTorus *ri = result + i;
         zero(ri, zparams);
         for (int32_t j = i - N + 1; j < N; j++) {
-            mul(ti, poly1+j, poly2+(i-j), zparams, alloc);
+            mul(ti, poly1 + j, poly2 + (i - j), zparams, alloc);
             add(ri, ri, ti, zparams);
         }
     }
@@ -155,26 +149,25 @@ void TorusPolynomial<BigTorus>::MultNaive_plain_aux(
 
 template<>
 void TorusPolynomial<BigTorus>::MultNaive_aux(
-    BigTorus *__restrict result,
-    const INT_TYPE *__restrict poly1,
-    const BigTorus *__restrict poly2,
-    const int32_t N,
-    const ZModuleParams<BigTorus> *const zparams,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        BigTorus *__restrict result,
+        const INT_TYPE *__restrict poly1,
+        const BigTorus *__restrict poly2,
+        const int32_t N,
+        const ZModuleParams<BigTorus> *const zparams,
+        TfheThreadContext *context,
+        Allocator alloc) {
     BigTorus *ti = alloc.newObject<BigTorus>(zparams, &alloc);
 
     for (int32_t i = 0; i < N; i++) {
-        BigTorus *ri = result+i;
+        BigTorus *ri = result + i;
         zero(ri, zparams);
 
         for (int32_t j = 0; j <= i; j++) {
-            mul(ti, poly1+j, poly2+(i-j), zparams, alloc);
+            mul(ti, poly1 + j, poly2 + (i - j), zparams, alloc);
             add(ri, ri, ti, zparams);
         }
         for (int32_t j = i + 1; j < N; j++) {
-            mul(ti, poly1+j, poly2+(N + i - j), zparams, alloc);
+            mul(ti, poly1 + j, poly2 + (N + i - j), zparams, alloc);
             sub(ri, ri, ti, zparams);
         }
     }
@@ -187,21 +180,20 @@ void TorusPolynomial<BigTorus>::MultNaive_aux(
  */
 template<>
 void TorusPolynomial<BigTorus>::MultNaive(
-    TorusPolynomial<BigTorus> *result,
-    const IntPolynomial<BigTorus> *poly1,
-    const TorusPolynomial<BigTorus> *poly2,
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<BigTorus> *result,
+        const IntPolynomial<BigTorus> *poly1,
+        const TorusPolynomial<BigTorus> *poly2,
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     assert(result != poly2);
 
     const int32_t N = params->N;
     const ZModuleParams<BigTorus> *const zparams =
-        params->zmodule_params;
+            params->zmodule_params;
 
     TorusPolynomial<BigTorus>::MultNaive_aux(result->coefs, poly1->coefs,
-        poly2->coefs, N, zparams, context, alloc.createStackChildAllocator());
+                                             poly2->coefs, N, zparams, context, alloc.createStackChildAllocator());
 }
 //
 /**
@@ -215,53 +207,49 @@ void TorusPolynomial<BigTorus>::MultNaive(
 // R of size = 2*size-1
 template<>
 void TorusPolynomial<BigTorus>::Karatsuba_aux(
-    BigTorus *R,
-    const INT_TYPE *A,
-    const BigTorus *B,
-    const int32_t size,
-    const char *buf,
-    const ZModuleParams<BigTorus> *const zparams,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        BigTorus *R,
+        const INT_TYPE *A,
+        const BigTorus *B,
+        const int32_t size,
+        const char *buf,
+        const ZModuleParams<BigTorus> *const zparams,
+        TfheThreadContext *context,
+        Allocator alloc) {
     abort(); //not implemented yet
 }
 
 // poly1, poly2 and result are polynomials mod X^N+1
 template<>
 void TorusPolynomial<BigTorus>::MultKaratsuba(
-    TorusPolynomial<BigTorus> *result,
-    const IntPolynomial<BigTorus> *poly1,
-    const TorusPolynomial<BigTorus> *poly2,
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<BigTorus> *result,
+        const IntPolynomial<BigTorus> *poly1,
+        const TorusPolynomial<BigTorus> *poly2,
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     abort(); //not implemented yet
 }
 
 // poly1, poly2 and result are polynomials mod X^N+1
 template<>
 void TorusPolynomial<BigTorus>::AddMulRKaratsuba(
-    TorusPolynomial<BigTorus> *result,
-    const IntPolynomial<BigTorus> *poly1,
-    const TorusPolynomial<BigTorus> *poly2,
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<BigTorus> *result,
+        const IntPolynomial<BigTorus> *poly1,
+        const TorusPolynomial<BigTorus> *poly2,
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     abort(); //not implemented yet
 }
 
 // poly1, poly2 and result are polynomials mod X^N+1
 template<>
 void TorusPolynomial<BigTorus>::SubMulRKaratsuba(
-    TorusPolynomial<BigTorus> *result,
-    const IntPolynomial<BigTorus> *poly1,
-    const TorusPolynomial<BigTorus> *poly2,
-    const PolynomialParams<BigTorus> *params,
-    TfheThreadContext *context,
-    Allocator alloc)
-{
+        TorusPolynomial<BigTorus> *result,
+        const IntPolynomial<BigTorus> *poly1,
+        const TorusPolynomial<BigTorus> *poly2,
+        const PolynomialParams<BigTorus> *params,
+        TfheThreadContext *context,
+        Allocator alloc) {
     abort(); //not implemented yet
 }

--- a/libtfhe/core/arithmetic/polynomial_torus_big.cpp
+++ b/libtfhe/core/arithmetic/polynomial_torus_big.cpp
@@ -34,7 +34,7 @@ void TorusPolynomial<BigTorus>::AddMulZ(
     BigTorus *r = result->coefs;
     const BigTorus *a = poly1->coefs;
     const BigTorus *b = poly2->coefs;
-    const ZModuleType *const zparams =
+    const ZModuleParams<BigTorus> *const zparams =
         params->zmodule_params;
 
     BigTorus *t = alloc.newObject<BigTorus>(zparams, &alloc);
@@ -74,7 +74,7 @@ void TorusPolynomial<BigTorus>::SubMulZ(
     BigTorus *r = result->coefs;
     const BigTorus *a = poly1->coefs;
     const BigTorus *b = poly2->coefs;
-    const ZModuleType *const zparams =
+    const ZModuleParams<BigTorus> *const zparams =
         params->zmodule_params;
 
     BigTorus *t = alloc.newObject<BigTorus>(zparams, &alloc);
@@ -109,7 +109,7 @@ double TorusPolynomial<BigTorus>::NormInftyDist(
 {
     const int32_t N = params->N;
     double norm = 0;
-    const ZModuleType *const zparams =
+    const ZModuleParams<BigTorus> *const zparams =
         params->zmodule_params;
 
     // Max between the coefficients of abs(poly1-poly2)
@@ -127,7 +127,7 @@ void TorusPolynomial<BigTorus>::MultNaive_plain_aux(
     const INT_TYPE *__restrict poly1,
     const BigTorus *__restrict poly2,
     const int32_t N,
-    const ZModuleType *const zparams,
+    const ZModuleParams<BigTorus> *const zparams,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -159,7 +159,7 @@ void TorusPolynomial<BigTorus>::MultNaive_aux(
     const INT_TYPE *__restrict poly1,
     const BigTorus *__restrict poly2,
     const int32_t N,
-    const ZModuleType *const zparams,
+    const ZModuleParams<BigTorus> *const zparams,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -188,7 +188,7 @@ void TorusPolynomial<BigTorus>::MultNaive_aux(
 template<>
 void TorusPolynomial<BigTorus>::MultNaive(
     TorusPolynomial<BigTorus> *result,
-    const IntPolynomial<INT_TYPE> *poly1,
+    const IntPolynomial<BigTorus> *poly1,
     const TorusPolynomial<BigTorus> *poly2,
     const PolynomialParams<BigTorus> *params,
     TfheThreadContext *context,
@@ -197,7 +197,7 @@ void TorusPolynomial<BigTorus>::MultNaive(
     assert(result != poly2);
 
     const int32_t N = params->N;
-    const ZModuleType *const zparams =
+    const ZModuleParams<BigTorus> *const zparams =
         params->zmodule_params;
 
     TorusPolynomial<BigTorus>::MultNaive_aux(result->coefs, poly1->coefs,
@@ -220,7 +220,7 @@ void TorusPolynomial<BigTorus>::Karatsuba_aux(
     const BigTorus *B,
     const int32_t size,
     const char *buf,
-    const ZModuleType *const zparams,
+    const ZModuleParams<BigTorus> *const zparams,
     TfheThreadContext *context,
     Allocator alloc)
 {
@@ -231,7 +231,7 @@ void TorusPolynomial<BigTorus>::Karatsuba_aux(
 template<>
 void TorusPolynomial<BigTorus>::MultKaratsuba(
     TorusPolynomial<BigTorus> *result,
-    const IntPolynomial<INT_TYPE> *poly1,
+    const IntPolynomial<BigTorus> *poly1,
     const TorusPolynomial<BigTorus> *poly2,
     const PolynomialParams<BigTorus> *params,
     TfheThreadContext *context,
@@ -244,7 +244,7 @@ void TorusPolynomial<BigTorus>::MultKaratsuba(
 template<>
 void TorusPolynomial<BigTorus>::AddMulRKaratsuba(
     TorusPolynomial<BigTorus> *result,
-    const IntPolynomial<INT_TYPE> *poly1,
+    const IntPolynomial<BigTorus> *poly1,
     const TorusPolynomial<BigTorus> *poly2,
     const PolynomialParams<BigTorus> *params,
     TfheThreadContext *context,
@@ -257,7 +257,7 @@ void TorusPolynomial<BigTorus>::AddMulRKaratsuba(
 template<>
 void TorusPolynomial<BigTorus>::SubMulRKaratsuba(
     TorusPolynomial<BigTorus> *result,
-    const IntPolynomial<INT_TYPE> *poly1,
+    const IntPolynomial<BigTorus> *poly1,
     const TorusPolynomial<BigTorus> *poly2,
     const PolynomialParams<BigTorus> *params,
     TfheThreadContext *context,


### PR DESCRIPTION
All polynomial related classes (IntPolynomial, TorusPolynomial and
PolynomialParams) are parametrized by a TORUS. Coefficient type of the
underlying polynomial representation is automatically chosen.

Modifications:
- uniformize template parameter name (TORUS_TYPE to TORUS)
- replace ZModuleType with direct ZModuleParams<TORUS>
- removed "ugly" ZModuleParams parameter switch in PolynomialParams