### PR TITLE
137-fortify-allocator-usage and misc bug fixes

### DIFF
--- a/libtfhe/core/allocator/ValgrindAllocator.h
+++ b/libtfhe/core/allocator/ValgrindAllocator.h
@@ -25,6 +25,14 @@ public:
 
     ~ValgrindAllocator();
 
+    ValgrindAllocator(const ValgrindAllocator &alloc) = delete;
+
+    ValgrindAllocator(ValgrindAllocator &&alloc) = default;
+
+    ValgrindAllocator &operator=(const ValgrindAllocator &alloc)= delete;
+
+    ValgrindAllocator &operator=(ValgrindAllocator &&alloc)= default;
+
     Allocator createStackChildAllocator(const size_t expected_size = default_stack_size);
 };
 

--- a/libtfhe/core/allocator/allocator.h
+++ b/libtfhe/core/allocator/allocator.h
@@ -75,6 +75,15 @@ public:
      */
     ~Allocator() {}
 
+    // An allocator cannot be copied. Move is ok, however.
+    Allocator(const Allocator &alloc) = delete;
+
+    Allocator(Allocator &&alloc) = default;
+
+    Allocator &operator=(const Allocator &alloc)= delete;
+
+    Allocator &operator=(Allocator &&alloc)= default;
+
     /**
      * Allocates and constructs a new object of type T, aligned with the specified alignment,
      * and call the constructor using args

--- a/libtfhe/core/arithmetic/big_int.cpp
+++ b/libtfhe/core/arithmetic/big_int.cpp
@@ -1,3 +1,4 @@
+#include <gmp.h>
 #include "big_int.h"
 
 BigInt::BigInt(int64_t value) {
@@ -8,30 +9,36 @@ void BigInt::destroy() {
     mpz_clear(data);
 }
 
-void clamp2p(BigInt *res, const ZModuleParams<BigTorus> *params) {
-    if (res->data->_mp_size > params->max_nbLimbs) {
-        res->data->_mp_size = params->max_nbLimbs;
+void tfhe_backend::clamp2p(BigInt *res, const ZModuleParams<BigTorus> *params) {
+    mpz_t &r = res->data;
+    if (r->_mp_size > params->max_nbLimbs) {
+        for (r->_mp_size = params->max_nbLimbs; r->_mp_size > 1; r->_mp_size--) {
+            if (r->_mp_d[r->_mp_size - 1] != 0) break;
+        }
         return;
     } else if (res->data->_mp_size < -params->max_nbLimbs) {
         res->data->_mp_size = -params->max_nbLimbs;
+        for (r->_mp_size = -params->max_nbLimbs; r->_mp_size < -1; r->_mp_size++) {
+            if (r->_mp_d[-r->_mp_size - 1] != 0) break;
+        }
         return;
     }
 }
 
-void zero(BigInt *res, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::zero(BigInt *res, const ZModuleParams<BigTorus> *params) {
     setvalue(res, (int64_t)0, params);
 }
 
-void copy(BigInt *res, const BigInt* src, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::copy(BigInt *res, const BigInt *src, const ZModuleParams<BigTorus> *params) {
     setvalue(res, src, params);
 }
 
-void add(BigInt *res, const BigInt *a, const BigInt *b, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::add(BigInt *res, const BigInt *a, const BigInt *b, const ZModuleParams<BigTorus> *params) {
     mpz_add(res->data, a->data, b->data);
     clamp2p(res, params);
 }
 
-void add(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::add(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> *params) {
     if (b >= 0)
         mpz_add_ui(res->data, a->data, uint64_t(b));
     else
@@ -39,16 +46,16 @@ void add(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> 
     clamp2p(res, params);
 }
 
-void add(BigInt *res, int64_t a, const BigInt *b, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::add(BigInt *res, int64_t a, const BigInt *b, const ZModuleParams<BigTorus> *params) {
     add(res, b, a, params);
 }
 
-void sub(BigInt *res, const BigInt *a, const BigInt *b, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::sub(BigInt *res, const BigInt *a, const BigInt *b, const ZModuleParams<BigTorus> *params) {
     mpz_sub(res->data, a->data, b->data);
     clamp2p(res, params);
 }
 
-void sub(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::sub(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> *params) {
     if (b >= 0)
         mpz_sub_ui(res->data, a->data, uint64_t(b));
     else
@@ -56,7 +63,7 @@ void sub(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> 
     clamp2p(res, params);
 }
 
-void sub(BigInt *res, int64_t a, const BigInt *b, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::sub(BigInt *res, int64_t a, const BigInt *b, const ZModuleParams<BigTorus> *params) {
     if (a >= 0)
         mpz_ui_sub(res->data, uint64_t(a), b->data);
     else
@@ -64,33 +71,33 @@ void sub(BigInt *res, int64_t a, const BigInt *b, const ZModuleParams<BigTorus> 
     clamp2p(res, params);
 }
 
-void mul(BigInt *res, const BigInt *a, const BigInt *b, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::mul(BigInt *res, const BigInt *a, const BigInt *b, const ZModuleParams<BigTorus> *params) {
     mpz_mul(res->data, a->data, b->data);
     clamp2p(res, params);
 }
 
-void mul(BigInt *res, int64_t a, const BigInt *b, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::mul(BigInt *res, int64_t a, const BigInt *b, const ZModuleParams<BigTorus> *params) {
     mpz_mul_si(res->data, b->data, a);
     clamp2p(res, params);
 }
 
-void mul(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::mul(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> *params) {
     mpz_mul_si(res->data, a->data, b);
     clamp2p(res, params);
 }
 
-void neg(BigInt *res, BigInt *a, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::neg(BigInt *res, BigInt *a, const ZModuleParams<BigTorus> *params) {
     mpz_neg(res->data, a->data);
 }
 
-void neg(BigInt *res, int64_t a, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::neg(BigInt *res, int64_t a, const ZModuleParams<BigTorus> *params) {
     mpz_set_si(res->data, -a);
 }
 
-void setvalue(BigInt *res, const BigInt *a, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::setvalue(BigInt *res, const BigInt *a, const ZModuleParams<BigTorus> *params) {
     mpz_set(res->data, a->data);
 }
 
-void setvalue(BigInt *res, const int64_t a, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::setvalue(BigInt *res, const int64_t a, const ZModuleParams<BigTorus> *params) {
     mpz_set_si(res->data, a);
 }

--- a/libtfhe/core/arithmetic/big_int.h
+++ b/libtfhe/core/arithmetic/big_int.h
@@ -29,87 +29,91 @@ public:
     PREVENT_STACK_COPY(BigInt);
 };
 
+namespace tfhe_backend {
+
 /**
  * @brief res := res truncated modulo 2^p
  * Very fast implementation using gmp internals
  * @param res the bigint to truncate
  * @param params bigint parameters
  */
-void clamp2p(BigInt *res, const ZModuleParams<BigTorus> *params);
+    void clamp2p(BigInt *res, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = 0
  */
-void zero(BigInt *res, const ZModuleParams<BigTorus> *params);
+    void zero(BigInt *res, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = src
  */
-void copy(BigInt *res, const BigInt* src, const ZModuleParams<BigTorus> *params);
+    void copy(BigInt *res, const BigInt *src, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a + b (truncated mod 2^p)
  */
-void add(BigInt *res, const BigInt *a, const BigInt *b, const ZModuleParams<BigTorus> *params);
+    void add(BigInt *res, const BigInt *a, const BigInt *b, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a + b (truncated mod 2^p)
  */
-void add(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> *params);
+    void add(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a + b (truncated mod 2^p)
  */
-void add(BigInt *res, int64_t a, const BigInt *b, const ZModuleParams<BigTorus> *params);
+    void add(BigInt *res, int64_t a, const BigInt *b, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a - b (truncated mod 2^p)
  */
-void sub(BigInt *res, const BigInt *a, const BigInt *b, const ZModuleParams<BigTorus> *params);
+    void sub(BigInt *res, const BigInt *a, const BigInt *b, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a - b (truncated mod 2^p)
  */
-void sub(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> *params);
+    void sub(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a - b (truncated mod 2^p)
  */
-void sub(BigInt *res, int64_t a, const BigInt *b, const ZModuleParams<BigTorus> *params);
+    void sub(BigInt *res, int64_t a, const BigInt *b, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a * b (truncated mod 2^p)
  */
-void mul(BigInt *res, const BigInt *a, const BigInt *b, const ZModuleParams<BigTorus> *params);
+    void mul(BigInt *res, const BigInt *a, const BigInt *b, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a * b (truncated mod 2^p)
  */
-void mul(BigInt *res, int64_t a, const BigInt *b, const ZModuleParams<BigTorus> *params);
+    void mul(BigInt *res, int64_t a, const BigInt *b, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a * b (truncated mod 2^p)
  */
-void mul(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> *params);
+    void mul(BigInt *res, const BigInt *a, int64_t b, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = -a (truncated mod 2^p)
  */
-void neg(BigInt *res, BigInt *a, const ZModuleParams<BigTorus> *params);
+    void neg(BigInt *res, BigInt *a, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = -a (truncated mod 2^p)
  */
-void neg(BigInt *res, int64_t a, const ZModuleParams<BigTorus> *params);
+    void neg(BigInt *res, int64_t a, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a (truncated mod 2^p)
  */
-void setvalue(BigInt *res, const BigInt *a, const ZModuleParams<BigTorus> *params);
+    void setvalue(BigInt *res, const BigInt *a, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a (truncated mod 2^p)
  */
-void setvalue(BigInt *res, const int64_t a, const ZModuleParams<BigTorus> *params);
+    void setvalue(BigInt *res, const int64_t a, const ZModuleParams<BigTorus> *params);
+
+}
 
 #endif //TFHE_BIGINT_H

--- a/libtfhe/core/arithmetic/big_torus.cpp
+++ b/libtfhe/core/arithmetic/big_torus.cpp
@@ -9,15 +9,15 @@ void BigTorus::destroy(const ZModuleParams<BigTorus> *params, Allocator *alloc) 
     alloc->deleteArray(params->max_nbLimbs, data);
 }
 
-void add(BigTorus *res, const BigTorus *a, const BigTorus *b, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::add(BigTorus *res, const BigTorus *a, const BigTorus *b, const ZModuleParams<BigTorus> *params) {
     mpn_add_n(res->data, a->data, b->data, params->max_nbLimbs);
 }
 
-void sub(BigTorus *res, const BigTorus *a, const BigTorus *b, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::sub(BigTorus *res, const BigTorus *a, const BigTorus *b, const ZModuleParams<BigTorus> *params) {
     mpn_sub_n(res->data, a->data, b->data, params->max_nbLimbs);
 }
 
-void mul(BigTorus *res, int64_t a, const BigTorus *b, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::mul(BigTorus *res, int64_t a, const BigTorus *b, const ZModuleParams<BigTorus> *params) {
     if (a >= 0) {
         mpn_mul_1(res->data, b->data, params->max_nbLimbs, uint64_t(a));
     } else {
@@ -44,7 +44,8 @@ static void mul_no_overlap(BigTorus *res, const BigInt *a, const BigTorus *b, co
     }
 }
 
-void mul(BigTorus *res, const BigInt *a, const BigTorus *b, const ZModuleParams<BigTorus> *params, Allocator alloc) {
+void tfhe_backend::mul(BigTorus *res, const BigInt *a, const BigTorus *b, const ZModuleParams<BigTorus> *params,
+                       Allocator alloc) {
     if (res!=b) {
         mul_no_overlap(res, a, b, params);
     } else {
@@ -55,11 +56,11 @@ void mul(BigTorus *res, const BigInt *a, const BigTorus *b, const ZModuleParams<
     }
 }
 
-void neg(BigTorus *res, const BigTorus *a, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::neg(BigTorus *res, const BigTorus *a, const ZModuleParams<BigTorus> *params) {
     mpn_neg(res->data, a->data, params->max_nbLimbs);
 }
 
-void from_double(BigTorus *reps, const double d, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::from_double(BigTorus *reps, const double d, const ZModuleParams<BigTorus> *params) {
     //dissect the input double: extract sign, exponent, mantissa
     static constexpr uint64_t mantissa_msb = (uint64_t(1) << 52);
     static constexpr uint64_t mantissa_mask = mantissa_msb - 1;
@@ -107,15 +108,15 @@ void from_double(BigTorus *reps, const double d, const ZModuleParams<BigTorus> *
     }
 }
 
-void zero(BigTorus *res, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::zero(BigTorus *res, const ZModuleParams<BigTorus> *params) {
     mpn_zero(res->data, params->max_nbLimbs);
 }
 
-void copy(BigTorus *res, const BigTorus* src, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::copy(BigTorus *res, const BigTorus *src, const ZModuleParams<BigTorus> *params) {
     mpn_copyi(res->data, src->data, params->max_nbLimbs);
 }
 
-void setPowHalf(BigTorus *res, const int k, const ZModuleParams<BigTorus> *params) {
+void tfhe_backend::setPowHalf(BigTorus *res, const int k, const ZModuleParams<BigTorus> *params) {
     zero(res, params);
     int idx = params->p - k;
     if (k <= 0 || idx < 0) return;
@@ -202,23 +203,27 @@ namespace {
     };
 }
 
-void approxPhase(BigTorus *res, const BigTorus *phase, uint64_t Msize, ZModuleParams<BigTorus> *params, Allocator alloc) {
+void
+tfhe_backend::approxPhase(BigTorus *res, const BigTorus *phase, uint64_t Msize, const ZModuleParams<BigTorus> *params,
+                          Allocator alloc) {
     TorusMsgSpace msgSpace(Msize, params, &alloc);
     msgSpace.roundPhase(res, phase);
 }
 
-uint64_t modSwitchFromTorus(const BigTorus *phase, uint64_t Msize, ZModuleParams<BigTorus> *params, Allocator alloc) {
+uint64_t tfhe_backend::modSwitchFromTorus(const BigTorus *phase, uint64_t Msize, const ZModuleParams<BigTorus> *params,
+                                          Allocator alloc) {
     TorusMsgSpace msgSpace(Msize, params, &alloc);
     return msgSpace.decrypt(phase);
 }
 
-void modSwitchToTorus(BigTorus *res, const uint64_t message, const uint64_t Msize, ZModuleParams<BigTorus> *params, Allocator alloc) {
+void tfhe_backend::modSwitchToTorus(BigTorus *res, const uint64_t message, const uint64_t Msize,
+                                    const ZModuleParams<BigTorus> *params, Allocator alloc) {
     const uint64_t mu = ((message % Msize)+Msize)%Msize; //between 0 and Msize-1
     TorusMsgSpace msgSpace(Msize, params, &alloc);
     msgSpace.encryptTrivial(res, mu);
 }
 
-double to_double(const BigTorus *a, const ZModuleParams<BigTorus> *params) {
+double tfhe_backend::to_double(const BigTorus *a, const ZModuleParams<BigTorus> *params) {
     // quick and dirty
     return double(int64_t(a->data[params->max_nbLimbs-1]))*pow(0.5,64);
 }

--- a/libtfhe/core/arithmetic/big_torus.h
+++ b/libtfhe/core/arithmetic/big_torus.h
@@ -24,46 +24,48 @@ public:
     PREVENT_STACK_COPY(BigTorus);
 };
 
+namespace tfhe_backend {
+
 /**
  * @brief res = 0
  */
-void zero(BigTorus *res, const ZModuleParams<BigTorus> *params);
+    void zero(BigTorus *res, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = src
  */
-void copy(BigTorus *res, const BigTorus* src, const ZModuleParams<BigTorus> *params);
+    void copy(BigTorus *res, const BigTorus *src, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = 2^-k
  */
-void setPowHalf(BigTorus *res, const int k, const ZModuleParams<BigTorus> *params);
+    void setPowHalf(BigTorus *res, const int k, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a + b
  */
-void add(BigTorus *res, const BigTorus *a, const BigTorus *b, const ZModuleParams<BigTorus> *params);
+    void add(BigTorus *res, const BigTorus *a, const BigTorus *b, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a - b
  */
-void sub(BigTorus *res, const BigTorus *a, const BigTorus *b, const ZModuleParams<BigTorus> *params);
+    void sub(BigTorus *res, const BigTorus *a, const BigTorus *b, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a * b
  */
-void mul(BigTorus *res, int64_t a, const BigTorus *b, const ZModuleParams<BigTorus> *params);
+    void mul(BigTorus *res, int64_t a, const BigTorus *b, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief res = a * b
  * WARNING: for this function, res and b must not overlap.
  */
-void mul(BigTorus *res, const BigInt *a, const BigTorus *b, const ZModuleParams<BigTorus> *params, Allocator alloc);
+    void mul(BigTorus *res, const BigInt *a, const BigTorus *b, const ZModuleParams<BigTorus> *params, Allocator alloc);
 
 /**
  * @brief res = -a
  */
-void neg(BigTorus *res, const BigTorus *a, const ZModuleParams<BigTorus> *params);
+    void neg(BigTorus *res, const BigTorus *a, const ZModuleParams<BigTorus> *params);
 
 
 /**
@@ -71,14 +73,14 @@ void neg(BigTorus *res, const BigTorus *a, const ZModuleParams<BigTorus> *params
  * @param d real to convert
  * @return torus value
  */
-void from_double(BigTorus *reps, const double d, const ZModuleParams<BigTorus> *params);
+    void from_double(BigTorus *reps, const double d, const ZModuleParams<BigTorus> *params);
 
 /**
  * @brief Converts torus to real number (mainly for printing).
  * @param x torus element to convert
  * @return real number
 */
-double to_double(const BigTorus *a, const ZModuleParams<BigTorus> *b);
+    double to_double(const BigTorus *a, const ZModuleParams<BigTorus> *b);
 
 /**
  * @brief Rounds the torus value to the nearest multiple of 1/Msize
@@ -86,7 +88,9 @@ double to_double(const BigTorus *a, const ZModuleParams<BigTorus> *b);
  * @param Msize discrete space size
  * @return approximated torus value
  */
-void approxPhase(BigTorus *res, const BigTorus *phase, uint64_t Msize, ZModuleParams<BigTorus> *params, Allocator alloc);
+    void
+    approxPhase(BigTorus *res, const BigTorus *phase, uint64_t Msize, const ZModuleParams<BigTorus> *params,
+                Allocator alloc);
 
 /**
  * @brief Mod-Rescale from the torus to Z/Msize.Z
@@ -95,7 +99,8 @@ void approxPhase(BigTorus *res, const BigTorus *phase, uint64_t Msize, ZModulePa
  * @param Msize discrete space size
  * @return discrete space value in [0, MSize[
  */
-uint64_t modSwitchFromTorus(const BigTorus *phase, uint64_t Msize, ZModuleParams<BigTorus> *params, Allocator alloc);
+    uint64_t
+    modSwitchFromTorus(const BigTorus *phase, uint64_t Msize, const ZModuleParams<BigTorus> *params, Allocator alloc);
 
 /**
  * @brief Converts discrete message space to torus
@@ -104,7 +109,9 @@ uint64_t modSwitchFromTorus(const BigTorus *phase, uint64_t Msize, ZModuleParams
  * @param Msize discrete space size
  * @return torus value
  */
-void modSwitchToTorus(BigTorus *res, const uint64_t mu, const uint64_t Msize, ZModuleParams<BigTorus> *params, Allocator alloc);
+    void modSwitchToTorus(BigTorus *res, const uint64_t mu, const uint64_t Msize, const ZModuleParams<BigTorus> *params,
+                          Allocator alloc);
 
+}
 
 #endif //TFHE_BIGTORUS_H

--- a/libtfhe/core/arithmetic/polynomial_big.cpp
+++ b/libtfhe/core/arithmetic/polynomial_big.cpp
@@ -1,5 +1,7 @@
 #include "polynomial.h"
 
+using namespace tfhe_backend;
+
 /**
  * Instantiate Polynomial class for big torus and int types
  */

--- a/libtfhe/core/arithmetic/polynomial_torus.cpp
+++ b/libtfhe/core/arithmetic/polynomial_torus.cpp
@@ -193,7 +193,7 @@ void TorusPolynomial<TORUS>::MultNaive(
             params->zmodule_params;
 
     TorusPolynomial<TORUS>::MultNaive_aux(result->coefs, poly1->coefs,
-                                          poly2->coefs, N, zparams, context, alloc);
+                                          poly2->coefs, N, zparams, context, alloc.createStackChildAllocator());
 }
 
 /**
@@ -221,7 +221,7 @@ void TorusPolynomial<TORUS>::Karatsuba_aux(
     //we stop the karatsuba recursion at h=4, because on my machine,
     //it seems to be optimal
     if (h <= 4) {
-        TorusPolynomial<TORUS>::MultNaive_plain_aux(R, A, B, size, zparams, context, alloc);
+        TorusPolynomial<TORUS>::MultNaive_plain_aux(R, A, B, size, zparams, context, alloc.createStackChildAllocator());
         return;
     }
 
@@ -240,10 +240,12 @@ void TorusPolynomial<TORUS>::Karatsuba_aux(
         Btemp[i] = B[i] + B[h + i];
 
     // Karatsuba recursivly
-    Karatsuba_aux(R, A, B, h, buf, zparams, context, alloc); // (R[0],R[2*h-2]), (A[0],A[h-1]), (B[0],B[h-1])
+    //TODO: get rid of the allocators in this function
+    Karatsuba_aux(R, A, B, h, buf, zparams, context,
+                  alloc.createStackChildAllocator()); // (R[0],R[2*h-2]), (A[0],A[h-1]), (B[0],B[h-1])
     Karatsuba_aux(R + size, A + h, B + h, h, buf, zparams, context,
-                  alloc); // (R[2*h],R[4*h-2]), (A[h],A[2*h-1]), (B[h],B[2*h-1])
-    Karatsuba_aux(Rtemp, Atemp, Btemp, h, buf, zparams, context, alloc);
+                  alloc.createStackChildAllocator()); // (R[2*h],R[4*h-2]), (A[h],A[2*h-1]), (B[h],B[2*h-1])
+    Karatsuba_aux(Rtemp, Atemp, Btemp, h, buf, zparams, context, alloc.createStackChildAllocator());
     R[sm1] = 0; //this one needs to be copy manually
     for (int32_t i = 0; i < sm1; ++i)
         Rtemp[i] -= R[i] + R[size + i];
@@ -269,7 +271,7 @@ void TorusPolynomial<TORUS>::MultKaratsuba(
             params->zmodule_params;
 
     // Karatsuba
-    Karatsuba_aux(R, poly1->coefs, poly2->coefs, N, buf, zparams, context, alloc);
+    Karatsuba_aux(R, poly1->coefs, poly2->coefs, N, buf, zparams, context, alloc.createStackChildAllocator());
 
     // reduction mod X^N+1
     for (int32_t i = 0; i < N - 1; ++i)
@@ -296,7 +298,7 @@ void TorusPolynomial<TORUS>::AddMulRKaratsuba(
             params->zmodule_params;
 
     // Karatsuba
-    Karatsuba_aux(R, poly1->coefs, poly2->coefs, N, buf, zparams, context, alloc);
+    Karatsuba_aux(R, poly1->coefs, poly2->coefs, N, buf, zparams, context, alloc.createStackChildAllocator());
 
     // reduction mod X^N+1
     for (int32_t i = 0; i < N - 1; ++i)
@@ -323,7 +325,7 @@ void TorusPolynomial<TORUS>::SubMulRKaratsuba(
             params->zmodule_params;
 
     // Karatsuba
-    Karatsuba_aux(R, poly1->coefs, poly2->coefs, N, buf, zparams, context, alloc);
+    Karatsuba_aux(R, poly1->coefs, poly2->coefs, N, buf, zparams, context, alloc.createStackChildAllocator());
 
     // reduction mod X^N+1
     for (int32_t i = 0; i < N - 1; ++i)

--- a/libtfhe/core/arithmetic/polynomial_torus_big.cpp
+++ b/libtfhe/core/arithmetic/polynomial_torus_big.cpp
@@ -2,6 +2,8 @@
 
 #include <cassert>
 
+using namespace tfhe_backend;
+
 /**
  * Instantiate TorusPolynomial class for big torus type
  */
@@ -39,7 +41,7 @@ void TorusPolynomial<BigTorus>::AddMulZ(
     BigTorus *t = alloc.newObject<BigTorus>(zparams, &alloc);
     for (int32_t i = 0; i < N; ++i) {
         copy(t, b + i, zparams);
-        mul(t, p, t, zparams, alloc);
+        mul(t, p, t, zparams, alloc.createStackChildAllocator());
         add(r + i, a + i, t, zparams);
     }
 }
@@ -53,7 +55,7 @@ void TorusPolynomial<BigTorus>::AddMulZTo(
         const PolynomialParams<BigTorus> *params,
         TfheThreadContext *context,
         Allocator alloc) {
-    TorusPolynomial<BigTorus>::AddMulZ(result, result, p, poly2, params, context, alloc);
+    TorusPolynomial<BigTorus>::AddMulZ(result, result, p, poly2, params, context, std::move(alloc));
 }
 
 // TorusPolynomial - p*TorusPolynomial
@@ -77,7 +79,7 @@ void TorusPolynomial<BigTorus>::SubMulZ(
     BigTorus *t = alloc.newObject<BigTorus>(zparams, &alloc);
     for (int32_t i = 0; i < N; ++i) {
         copy(t, b + i, zparams);
-        mul(t, p, t, zparams, alloc);
+        mul(t, p, t, zparams, alloc.createStackChildAllocator());
         sub(r + i, a + i, t, zparams);
     }
 }
@@ -91,7 +93,7 @@ void TorusPolynomial<BigTorus>::SubMulZTo(
         const PolynomialParams<BigTorus> *params,
         TfheThreadContext *context,
         Allocator alloc) {
-    TorusPolynomial<BigTorus>::SubMulZ(result, result, p, poly2, params, context, alloc);
+    TorusPolynomial<BigTorus>::SubMulZ(result, result, p, poly2, params, context, std::move(alloc));
 }
 
 // Infinity norm of the distance between two TorusPolynomial
@@ -132,7 +134,7 @@ void TorusPolynomial<BigTorus>::MultNaive_plain_aux(
         BigTorus *ri = result + i;
         zero(ri, zparams);
         for (int32_t j = 0; j <= i; j++) {
-            mul(ti, poly1 + j, poly2 + (i - j), zparams, alloc);
+            mul(ti, poly1 + j, poly2 + (i - j), zparams, alloc.createStackChildAllocator());
             add(ri, ri, ti, zparams);
         }
     }
@@ -141,7 +143,7 @@ void TorusPolynomial<BigTorus>::MultNaive_plain_aux(
         BigTorus *ri = result + i;
         zero(ri, zparams);
         for (int32_t j = i - N + 1; j < N; j++) {
-            mul(ti, poly1 + j, poly2 + (i - j), zparams, alloc);
+            mul(ti, poly1 + j, poly2 + (i - j), zparams, alloc.createStackChildAllocator());
             add(ri, ri, ti, zparams);
         }
     }
@@ -163,11 +165,11 @@ void TorusPolynomial<BigTorus>::MultNaive_aux(
         zero(ri, zparams);
 
         for (int32_t j = 0; j <= i; j++) {
-            mul(ti, poly1 + j, poly2 + (i - j), zparams, alloc);
+            mul(ti, poly1 + j, poly2 + (i - j), zparams, alloc.createStackChildAllocator());
             add(ri, ri, ti, zparams);
         }
         for (int32_t j = i + 1; j < N; j++) {
-            mul(ti, poly1 + j, poly2 + (N + i - j), zparams, alloc);
+            mul(ti, poly1 + j, poly2 + (N + i - j), zparams, alloc.createStackChildAllocator());
             sub(ri, ri, ti, zparams);
         }
     }

--- a/libtfhe/core/arithmetic/torus_utils_big.h
+++ b/libtfhe/core/arithmetic/torus_utils_big.h
@@ -37,7 +37,7 @@ public:
      * @return approximated torus value
      */
     static void approxPhase(TORUS *res, const TORUS *phase, const uint64_t Msize, const ZModuleParams<TORUS> *params, Allocator alloc) {
-        approxPhase(res, phase, Msize, params, alloc);
+        tfhe_backend::approxPhase(res, phase, Msize, params, std::move(alloc));
     }
 
     /**
@@ -48,7 +48,7 @@ public:
      * @return discrete space value in [0, MSize[
      */
     static uint64_t modSwitchFromTorus(const TORUS *phase, const uint64_t Msize, const ZModuleParams<TORUS> *params, Allocator alloc) {
-        return modSwitchFromTorus(phase, Msize, params, alloc);
+        return tfhe_backend::modSwitchFromTorus(phase, Msize, params, std::move(alloc));
     }
 
     /**
@@ -59,7 +59,7 @@ public:
      * @return torus value
      */
     static void modSwitchToTorus(TORUS *res, const uint64_t mu, const uint64_t Msize, const ZModuleParams<TORUS> *params, Allocator alloc) {
-        modSwitchToTorus(res, mu, Msize, params, alloc);
+        tfhe_backend::modSwitchToTorus(res, mu, Msize, params, std::move(alloc));
     }
 
     /**
@@ -70,6 +70,7 @@ public:
      * @return double value of the infinity norm
      */
     static double normInftyDist(const TORUS *t1, const TORUS *t2, const ZModuleParams<TORUS> *params) {
+        abort(); //TODO the code below won't do mod 1 properly (e.g. dist(0.01,0.99) is wrong): add a distance function to the torus
         return abs(TorusUtils<TORUS>::to_double(t1, params)-TorusUtils<TORUS>::to_double(t2, params)); // quick and dirty :P
     }
 };

--- a/test/test_bignum.cpp
+++ b/test/test_bignum.cpp
@@ -7,6 +7,7 @@
 #include "gmpxx.h"
 
 using namespace std;
+using namespace tfhe_backend;
 
 TEST(BigNum, BigIntAllocSet) {
     // here, we test a few constructors with or without value


### PR DESCRIPTION
* Declares the allocator non copyable.
  If you need to pass an allocator by value, use either:
```    alloc.createStackChildAllocator()```
    or
```    std::move(alloc)```
  the second one can be used ONLY if the allocator is NOT used in the current function, and just forwarded to the child.
* Fixes a recurse-infinitely problem with a namespace
* Also, fixes wrong handling of leading zeros in BigInt clamp2p function. 
   (the most significant limb must not be 0 in a mpz_t, else arithmetic is wrong)