### PR TITLE
Fix build on macosx

### DIFF
--- a/src/libtfhe/fft_processors/fftw/CMakeLists.txt
+++ b/src/libtfhe/fft_processors/fftw/CMakeLists.txt
@@ -12,5 +12,6 @@ set(HEADERS
     lagrangehalfc_impl.h
     )
 
+include_directories(${FFTW_INCLUDES})
 add_library(tfhe-fft-fftw OBJECT ${SRCS} ${HEADERS})
 set_property(TARGET tfhe-fft-fftw PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
It did not find the "fftw3.h" when we build the tests. This small change fix the build. I don't think some side effects will ocur on linux platform. Thanks for this amazing work.