### PR TITLE
Fix initialization of LweSample

### DIFF
--- a/src/libtfhe/lwesamples.cpp
+++ b/src/libtfhe/lwesamples.cpp
@@ -2,9 +2,8 @@
 #include "lweparams.h"
 
 
-LweSample::LweSample(const LweParams* params)
-{
-	this->a = new Torus32[params->n];
+LweSample::LweSample(const LweParams* params) {
+    this->a = new Torus32[params->n]();
     this->b = 0;
     this->current_variance = 0.;
 }


### PR DESCRIPTION
init_LweSample currently doesn't actually initialize the values in a; we use array value-initialization syntax to fix this.